### PR TITLE
Fix: Import missing components in Calendar

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -19,7 +19,9 @@ import {
   FormControlLabel,
   Radio,
   FormControl,
-  FormLabel
+  FormLabel,
+  Tooltip, // Added
+  ColorLensIcon // Added
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';


### PR DESCRIPTION
Added imports for ColorLensIcon and Tooltip from @mui/material in client/src/components/Calendar.js to resolve undefined errors.