### PR TITLE
Add dark mode toggle

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -9,7 +9,7 @@ import {
   useMediaQuery
 } from '@mui/material';
 import axios from 'axios';
-import { createPastelColor } from './calendar/colorUtils';
+import { createPastelColor, createDarkPastelColor } from './calendar/colorUtils';
 import UserPreferences from './calendar/UserPreferences';
 import AddEventDialog from './calendar/AddEventDialog';
 
@@ -46,7 +46,7 @@ const Calendar = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [userPreferences, setUserPreferences] = useState({
     name: '',
-    color: '#4CAF50'
+    color: '#66BB6A'
   });
   const [newEvent, setNewEvent] = useState({
     timeSlot: '',
@@ -54,6 +54,7 @@ const Calendar = () => {
     section: 'day'
   });
   const [selectedColor, setSelectedColor] = useState('#008080');
+  const [darkMode, setDarkMode] = useState(false);
   const [activeEventId, setActiveEventId] = useState(null);
   const isMobile = useMediaQuery('(max-width:599px)');
 
@@ -194,8 +195,18 @@ const Calendar = () => {
     return days;
   };
 
-  const pastelColor = useMemo(() => createPastelColor(userPreferences.color), [userPreferences.color]);
-  const darkColor = useMemo(() => darkenColor(userPreferences.color), [userPreferences.color]);
+  const pastelColor = useMemo(
+    () =>
+      darkMode
+        ? createDarkPastelColor(userPreferences.color)
+        : createPastelColor(userPreferences.color),
+    [userPreferences.color, darkMode]
+  );
+  const darkColor = useMemo(
+    () =>
+      darkMode ? userPreferences.color : darkenColor(userPreferences.color),
+    [userPreferences.color, darkMode]
+  );
 
   const handleDialogClose = useCallback(() => {
     setOpenDialog(false);
@@ -232,12 +243,13 @@ const Calendar = () => {
   }
 
   return (
-    <Box sx={{ 
-      p: 4, 
+    <Box sx={{
+      p: 4,
       height: { xs: 'auto', sm: '92.5vh' },
       minHeight: { xs: '100vh', sm: 'auto' },
       '--calendar-bg': pastelColor,
       backgroundColor: 'var(--calendar-bg)',
+      color: darkMode ? '#fff' : 'inherit',
       borderRadius: 2,
       fontFamily: 'Nunito, sans-serif',
       transition: 'background-color 0.5s ease',
@@ -287,6 +299,8 @@ const Calendar = () => {
         setUserPreferences={setUserPreferences}
         selectedColor={selectedColor}
         setSelectedColor={setSelectedColor}
+        darkMode={darkMode}
+        setDarkMode={setDarkMode}
       />
 
       <Paper sx={{ 
@@ -331,6 +345,7 @@ const Calendar = () => {
                 formatJoiners={formatJoiners}
                 isMobile={isMobile}
                 activeEventId={activeEventId}
+                darkMode={darkMode}
               />
             );
           })}
@@ -347,6 +362,7 @@ const Calendar = () => {
         handleKeyPress={handleKeyPress}
         dialogError={dialogError}
         userPreferences={userPreferences}
+        darkMode={darkMode}
       />
     </Box>
   );

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -24,7 +24,8 @@ const AddEventDialog = ({
   handleSubmit,
   handleKeyPress,
   dialogError,
-  userPreferences
+  userPreferences,
+  darkMode
 }) => {
   return (
     <Dialog 
@@ -36,7 +37,9 @@ const AddEventDialog = ({
           fontFamily: 'Nunito, sans-serif',
           margin: { xs: '16px', sm: '32px' },
           position: { xs: 'absolute', sm: 'relative' },
-          top: { xs: '10%', sm: 'auto' }
+          top: { xs: '10%', sm: 'auto' },
+          backgroundColor: darkMode ? '#424242' : 'white',
+          color: darkMode ? '#fff' : 'inherit'
         }
       }}
     >

--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -24,7 +24,8 @@ const DayColumn = ({
   formatJoiners,
   userPreferences,
   isMobile,
-  activeEventId
+  activeEventId,
+  darkMode
 }) => {
   const handleSectionClick = (section, e) => {
     if (!isMobile) {
@@ -39,8 +40,8 @@ const DayColumn = ({
       sm
       key={index}
       sx={{
-        borderRight: { sm: index < 6 ? '1px solid #e0e0e0' : 'none' },
-        borderBottom: { xs: index < 6 ? '1px solid #e0e0e0' : 'none', sm: 'none' },
+        borderRight: { sm: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none' },
+        borderBottom: { xs: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none', sm: 'none' },
         '&:last-child': {
           borderRight: 'none',
           borderBottom: 'none'
@@ -57,7 +58,9 @@ const DayColumn = ({
       <Box
         sx={{
           p: 2,
-          backgroundColor: isWeekend(date) ? '#F5F5F5' : 'white',
+          backgroundColor: darkMode
+            ? (isWeekend(date) ? '#383838' : '#303030')
+            : isWeekend(date) ? '#F5F5F5' : 'white',
           position: 'relative',
           display: 'flex',
           flexDirection: 'column',

--- a/client/src/components/calendar/UserPreferences.js
+++ b/client/src/components/calendar/UserPreferences.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Paper, Grid, TextField, Box } from '@mui/material';
+import { Paper, Grid, TextField, Box, Switch, FormControlLabel } from '@mui/material';
 import ColorLensIcon from '@mui/icons-material/ColorLens';
 import { COLORS, getTextColor } from './colorUtils';
 
-const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, setSelectedColor }) => {
+const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, setSelectedColor, darkMode, setDarkMode }) => {
   return (
     <Paper sx={{ 
       p: 2, 
@@ -90,8 +90,19 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
                   left: 0
                 }}
               />
-              <ColorLensIcon sx={{ color: getTextColor(selectedColor), fontSize: 20 }} />
-            </Box>
+            <ColorLensIcon sx={{ color: getTextColor(selectedColor), fontSize: 20 }} />
+          </Box>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={darkMode}
+                onChange={(e) => setDarkMode(e.target.checked)}
+                color="primary"
+              />
+            }
+            label="Dark Mode"
+            sx={{ ml: 2 }}
+          />
           </Box>
         </Grid>
       </Grid>

--- a/client/src/components/calendar/colorUtils.js
+++ b/client/src/components/calendar/colorUtils.js
@@ -1,12 +1,13 @@
 // Color constants
+// Slightly lighter presets so they look good on a dark background as well
 export const COLORS = [
-  { value: '#4CAF50', label: 'Green' },
-  { value: '#2196F3', label: 'Blue' },
-  { value: '#FF9800', label: 'Orange' },
-  { value: '#9C27B0', label: 'Purple' },
-  { value: '#F44336', label: 'Red' },
-  { value: '#FF80AB', label: 'Pink' },
-  { value: '#795548', label: 'Brown' }
+  { value: '#66BB6A', label: 'Green' },
+  { value: '#64B5F6', label: 'Blue' },
+  { value: '#FFB74D', label: 'Orange' },
+  { value: '#BA68C8', label: 'Purple' },
+  { value: '#EF5350', label: 'Red' },
+  { value: '#FF99C8', label: 'Pink' },
+  { value: '#A1887F', label: 'Brown' }
 ];
 
 // Function to convert hex to RGB
@@ -43,12 +44,24 @@ export const getTextColor = (backgroundColor) => {
 export const createPastelColor = (hex) => {
   const rgb = hexToRgb(hex);
   if (!rgb) return hex;
-  
+
   // Mix with white to create a very light pastel (80% white, 20% color)
   const pastelR = Math.round((rgb.r * 0.2) + (255 * 0.8));
   const pastelG = Math.round((rgb.g * 0.2) + (255 * 0.8));
   const pastelB = Math.round((rgb.b * 0.2) + (255 * 0.8));
-  
+
+  return `rgb(${pastelR}, ${pastelG}, ${pastelB})`;
+};
+
+// Function to create a dark pastel version of a color (60% black, 40% color)
+export const createDarkPastelColor = (hex) => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return hex;
+
+  const pastelR = Math.round(rgb.r * 0.4);
+  const pastelG = Math.round(rgb.g * 0.4);
+  const pastelB = Math.round(rgb.b * 0.4);
+
   return `rgb(${pastelR}, ${pastelG}, ${pastelB})`;
 };
 


### PR DESCRIPTION
## Summary
- add lighter preset colors and dark pastel helper
- implement dark mode toggle in `UserPreferences`
- wire dark mode through `Calendar`, `DayColumn`, and `AddEventDialog`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407726247c8325b1bf5f78595f8620