### PR TITLE
Fix favicon file references

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,7 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/web-app-manifest-192x192.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <title>Drop In</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- fix `apple-touch-icon` path
- include favicon sizes for PNGs

## Testing
- `npm test` *(fails: Missing script)*
- `cd client && npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6841ea881d8883259fdac3df1e61aac4