### PR TITLE
Fix viewport height accounting for padding

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -245,8 +245,8 @@ const Calendar = () => {
   return (
     <Box sx={{
       p: 4,
-      height: { xs: 'auto', sm: '92.5vh' },
-      minHeight: { xs: '100vh', sm: 'auto' },
+      height: { xs: 'calc(100dvh - 64px)', sm: 'calc(100vh - 64px)' },
+      minHeight: { xs: 'calc(100dvh - 64px)', sm: 'calc(100vh - 64px)' },
       '--calendar-bg': pastelColor,
       backgroundColor: 'var(--calendar-bg)',
       color: darkMode ? '#fff' : 'inherit',

--- a/client/src/components/calendar/UserPreferences.js
+++ b/client/src/components/calendar/UserPreferences.js
@@ -114,7 +114,9 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
               />
             }
             label={
-              <DarkModeIcon sx={{ fontSize: 28, verticalAlign: 'middle' }} />
+              <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
+                <DarkModeIcon sx={{ fontSize: 28 }} />
+              </Box>
             }
             sx={{
               ml: { xs: 0, sm: 2 },


### PR DESCRIPTION
## Summary
- ensure calendar height subtracts padding so the whole component fits the viewport
- vertically center dark mode icon within preferences

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --silent` in `client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684319e5b99083259996fae64ef48ab7