### PR TITLE
Fix favicon links and lighten dark mode dialog

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,6 +6,8 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="192x192" href="%PUBLIC_URL%/android-chrome-192x192.png" />
+    <link rel="icon" type="image/png" sizes="512x512" href="%PUBLIC_URL%/android-chrome-512x512.png" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <title>Drop In</title>
   </head>

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -38,7 +38,7 @@ const AddEventDialog = ({
           margin: { xs: '16px', sm: '32px' },
           position: { xs: 'absolute', sm: 'relative' },
           top: { xs: '10%', sm: 'auto' },
-          backgroundColor: darkMode ? '#424242' : 'white',
+          backgroundColor: darkMode ? '#616161' : 'white',
           color: darkMode ? '#fff' : 'inherit'
         }
       }}
@@ -82,10 +82,17 @@ const AddEventDialog = ({
           sx={{ mb: 2 }}
           placeholder={selectedDate ? (newEvent.section === 'evening' ? '6-7pm' : '9-5') : ''}
           InputProps={{
-            sx: { fontFamily: 'Nunito, sans-serif' }
+            sx: {
+              fontFamily: 'Nunito, sans-serif',
+              backgroundColor: darkMode ? '#757575' : 'white',
+              color: darkMode ? '#fff' : 'inherit',
+              '& fieldset': {
+                borderColor: darkMode ? '#bbb' : 'inherit'
+              }
+            }
           }}
           InputLabelProps={{
-            sx: { fontFamily: 'Nunito, sans-serif' }
+            sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
           }}
         />
         <TextField
@@ -96,10 +103,17 @@ const AddEventDialog = ({
           onChange={(e) => setNewEvent({ ...newEvent, location: e.target.value })}
           onKeyPress={handleKeyPress}
           InputProps={{
-            sx: { fontFamily: 'Nunito, sans-serif' }
+            sx: {
+              fontFamily: 'Nunito, sans-serif',
+              backgroundColor: darkMode ? '#757575' : 'white',
+              color: darkMode ? '#fff' : 'inherit',
+              '& fieldset': {
+                borderColor: darkMode ? '#bbb' : 'inherit'
+              }
+            }
           }}
           InputLabelProps={{
-            sx: { fontFamily: 'Nunito, sans-serif' }
+            sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
           }}
         />
       </DialogContent>


### PR DESCRIPTION
## Summary
- include android favicon sizes in HTML
- brighten the dark mode AddEventDialog UI

## Testing
- `npm test --prefix client -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae6f352083258f6822b01a6ed262