### PR TITLE
Fix dark mode init and color picker bug

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -10,6 +10,14 @@
     <link rel="icon" type="image/png" sizes="512x512" href="%PUBLIC_URL%/android-chrome-512x512.png" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/apple-touch-icon.png" />
     <title>Drop In</title>
+    <script>
+      (function() {
+        try {
+          var dark = localStorage.getItem('darkMode') === 'true';
+          if (dark) document.documentElement.classList.add('dark');
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -9,7 +9,7 @@ import {
   useMediaQuery
 } from '@mui/material';
 import axios from 'axios';
-import { createPastelColor, createDarkPastelColor } from './calendar/colorUtils';
+import { createPastelColor, createDarkPastelColor, COLORS } from './calendar/colorUtils';
 import UserPreferences from './calendar/UserPreferences';
 import AddEventDialog from './calendar/AddEventDialog';
 
@@ -58,7 +58,10 @@ const Calendar = () => {
   });
   const [selectedColor, setSelectedColor] = useState(() => {
     const storedColor = localStorage.getItem('preferredColor');
-    return storedColor || '#008080';
+    if (storedColor && !COLORS.find(c => c.value === storedColor)) {
+      return storedColor;
+    }
+    return '#008080';
   });
   const [darkMode, setDarkMode] = useState(() => {
     const storedDark = localStorage.getItem('darkMode');
@@ -81,6 +84,10 @@ const Calendar = () => {
 
   useEffect(() => {
     localStorage.setItem('darkMode', darkMode);
+  }, [darkMode]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', darkMode);
   }, [darkMode]);
 
   const fetchData = useCallback(async () => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,8 @@
 body {
   margin: 0;
 }
+
+html.dark body {
+  background-color: #303030;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- avoid highlighting custom color picker when preset is selected
- persist dark mode class on page load
- set up global dark mode styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848cd6bf3e883258a4efed7a0eee705