### PR TITLE
Add random color change on header click

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -232,6 +232,16 @@ const Calendar = () => {
     [userPreferences.color, darkMode]
   );
 
+  const handleHeaderClick = useCallback(() => {
+    const randomColor = `#${Math.floor(Math.random() * 16777215)
+      .toString(16)
+      .padStart(6, '0')}`;
+
+    // Always apply the random color and show it in the palette icon
+    setSelectedColor(randomColor);
+    setUserPreferences((prev) => ({ ...prev, color: randomColor }));
+  }, [userPreferences.color]);
+
   const handleDialogClose = useCallback(() => {
     setOpenDialog(false);
     setDialogError(null);
@@ -295,8 +305,19 @@ const Calendar = () => {
             fontWeight: 700,
             fontFamily: 'Courgette, cursive',
             letterSpacing: '-0.5px',
-            transition: 'color 0.5s ease'
+            userSelect: 'none',
+            transition: 'color 0.5s ease, transform 0.2s ease, text-shadow 0.2s ease',
+            textShadow: '1px 1px 3px rgba(0,0,0,0.25)',
+            cursor: 'pointer',
+            '&:hover': {
+              transform: 'scale(1.05)',
+              textShadow: '2px 2px 4px rgba(0,0,0,0.4)'
+            },
+            '&:active': {
+              transform: 'scale(0.95)'
+            }
           }}
+          onClick={handleHeaderClick}
         >
           Drop in!
         </Typography>


### PR DESCRIPTION
## Summary
- add a click handler for the "Drop in!" header that picks a random color
- style header with drop shadow and hover effect
- prevent highlighting, add active feedback, and show color in palette icon

## Testing
- `npm test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684ad8073c2483259d766420260c920a