### PR TITLE
Remove unnecessary useCallback dependency

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -240,7 +240,7 @@ const Calendar = () => {
     // Always apply the random color and show it in the palette icon
     setSelectedColor(randomColor);
     setUserPreferences((prev) => ({ ...prev, color: randomColor }));
-  }, [userPreferences.color]);
+  }, []);
 
   const handleDialogClose = useCallback(() => {
     setOpenDialog(false);


### PR DESCRIPTION
## Summary
- remove `userPreferences.color` from `handleHeaderClick` dependencies

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684add2c07388325a4385032f89f80e5