### PR TITLE
Add event icon picker

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -54,7 +54,8 @@ const Calendar = () => {
   const [newEvent, setNewEvent] = useState({
     timeSlot: '',
     location: '',
-    section: 'day'
+    section: 'day',
+    icon: ''
   });
   const [selectedColor, setSelectedColor] = useState(() => {
     const storedColor = localStorage.getItem('preferredColor');
@@ -127,7 +128,8 @@ const Calendar = () => {
     setNewEvent({
       timeSlot: '',
       location: '',
-      section: section
+      section: section,
+      icon: ''
     });
     setOpenDialog(true);
   }, [userPreferences.name]);

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -6,6 +6,7 @@ import {
   DialogActions,
   Button,
   TextField,
+  Box,
   FormControl,
   FormLabel,
   RadioGroup,
@@ -14,6 +15,8 @@ import {
   Alert
 } from '@mui/material';
 import { getTextColor } from './colorUtils';
+import IconPickerDialog from './IconPickerDialog';
+import * as Icons from '@mui/icons-material';
 
 const AddEventDialog = ({
   open,
@@ -27,6 +30,11 @@ const AddEventDialog = ({
   userPreferences,
   darkMode
 }) => {
+  const [iconDialogOpen, setIconDialogOpen] = useState(false);
+
+  const handleIconSelect = (icon) => {
+    setNewEvent({ ...newEvent, icon });
+  };
   return (
     <Dialog 
       open={open} 
@@ -116,6 +124,39 @@ const AddEventDialog = ({
             sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
           }}
         />
+        <Button
+          variant="outlined"
+          onClick={() => setIconDialogOpen(true)}
+          sx={{
+            mt: 2,
+            textTransform: 'none',
+            fontFamily: 'Nunito, sans-serif'
+          }}
+        >
+          {newEvent.icon ? 'Change Icon' : 'Select Icon'}
+        </Button>
+        {newEvent.icon && (
+          <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
+            <Box
+              sx={{
+                width: 48,
+                height: 48,
+                borderRadius: '50%',
+                backgroundColor: darkMode ? '#757575' : '#eee',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 32
+              }}
+            >
+              {Icons[newEvent.icon] ? (
+                React.createElement(Icons[newEvent.icon])
+              ) : (
+                <span>{newEvent.icon}</span>
+              )}
+            </Box>
+          </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button 
@@ -148,6 +189,11 @@ const AddEventDialog = ({
           add
         </Button>
       </DialogActions>
+      <IconPickerDialog
+        open={iconDialogOpen}
+        onClose={() => setIconDialogOpen(false)}
+        onSelect={handleIconSelect}
+      />
     </Dialog>
   );
 };

--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import * as Icons from '@mui/icons-material';
 import { createHighlightColor, getTextColor, isWeekend } from './colorUtils';
 
 const DayColumn = ({
@@ -169,6 +170,50 @@ const DayColumn = ({
                 }}
                 onClick={(e) => handleEventClick(a, e)}
               >
+                {a.icon && (
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: 8,
+                      left: 8,
+                      width: 32,
+                      height: 32,
+                      borderRadius: '50%',
+                      backgroundColor: 'rgba(255,255,255,0.3)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    {Icons[a.icon] ? (
+                      React.createElement(Icons[a.icon], { fontSize: 'small' })
+                    ) : (
+                      <span style={{ fontSize: '1rem' }}>{a.icon}</span>
+                    )}
+                  </Box>
+                )}
+                {a.icon && (
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: 8,
+                      left: 8,
+                      width: 32,
+                      height: 32,
+                      borderRadius: '50%',
+                      backgroundColor: 'rgba(255,255,255,0.3)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center'
+                    }}
+                  >
+                    {Icons[a.icon] ? (
+                      React.createElement(Icons[a.icon], { fontSize: 'small' })
+                    ) : (
+                      <span style={{ fontSize: '1rem' }}>{a.icon}</span>
+                    )}
+                  </Box>
+                )}
                 <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
                   <Box sx={{ flex: 1, minWidth: 0 }}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5, position: 'relative', minHeight: '40px' }}>

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -7,6 +7,7 @@ import {
   Tooltip 
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
+import * as Icons from '@mui/icons-material';
 import { getTextColor } from './colorUtils';
 
 const Event = memo(({ 
@@ -43,6 +44,28 @@ const Event = memo(({
         onEventClick(event, e);
       }}
     >
+      {event.icon && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 8,
+            left: 8,
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            backgroundColor: 'rgba(255,255,255,0.3)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          {Icons[event.icon] ? (
+            React.createElement(Icons[event.icon], { fontSize: 'small' })
+          ) : (
+            <span style={{ fontSize: '1rem' }}>{event.icon}</span>
+          )}
+        </Box>
+      )}
       <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>

--- a/client/src/components/calendar/IconPickerDialog.js
+++ b/client/src/components/calendar/IconPickerDialog.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Tabs,
+  Tab,
+  Box,
+  IconButton
+} from '@mui/material';
+import * as Icons from '@mui/icons-material';
+
+const emojiList = [
+  '😀','😁','😂','😊','😍','🤔','😎','🎉','🎂','🍕','🍔','🍻','🎵','🏃','⭐','🔥','💻','📚','✈️','🚀'
+];
+
+const IconPickerDialog = ({ open, onClose, onSelect }) => {
+  const [tab, setTab] = useState(0);
+  const iconNames = Object.keys(Icons);
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Select Icon</DialogTitle>
+      <Tabs value={tab} onChange={(e,v)=>setTab(v)} centered>
+        <Tab label="Icons" />
+        <Tab label="Emoji" />
+      </Tabs>
+      <DialogContent dividers>
+        {tab === 0 ? (
+          <Box sx={{ display:'flex', flexWrap:'wrap', gap:1, maxHeight:300, overflowY:'auto' }}>
+            {iconNames.map((name) => {
+              const IconComp = Icons[name];
+              return (
+                <IconButton key={name} onClick={() => { onSelect(name); onClose(); }}>
+                  <IconComp />
+                </IconButton>
+              );
+            })}
+          </Box>
+        ) : (
+          <Box sx={{ display:'flex', flexWrap:'wrap', gap:1, maxHeight:300, overflowY:'auto' }}>
+            {emojiList.map((emo) => (
+              <IconButton key={emo} onClick={() => { onSelect(emo); onClose(); }}>
+                <span style={{ fontSize: '24px' }}>{emo}</span>
+              </IconButton>
+            ))}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default IconPickerDialog;

--- a/server.js
+++ b/server.js
@@ -57,6 +57,7 @@ const availabilitySchema = new mongoose.Schema({
   location: String,
   name: String,
   color: String,
+  icon: String,
   section: {
     type: String,
     enum: ['day', 'evening'],


### PR DESCRIPTION
## Summary
- allow selecting an icon when creating events
- show Google Material icons & emojis in a picker dialog
- save icon on the server
- display the chosen icon on calendar events

## Testing
- `npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ae7f51fc48325adb2e485e6f7f3a1