### PR TITLE
Fix event icon layout and emoji rendering

### DIFF
--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -44,32 +44,29 @@ const Event = memo(({
         onEventClick(event, e);
       }}
     >
-      {event.icon && (
-        <Box
-          sx={{
-            position: 'absolute',
-            top: 8,
-            left: 8,
-            width: 32,
-            height: 32,
-            borderRadius: '50%',
-            backgroundColor: 'rgba(255,255,255,0.3)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-          }}
-        >
-          {Icons[event.icon] ? (
-            React.createElement(Icons[event.icon], { fontSize: 'small' })
-          ) : (
-            <span style={{ fontSize: '1rem' }}>{event.icon}</span>
-          )}
-        </Box>
-      )}
-      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+        {event.icon && (
+          <Box
+            sx={{
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              backgroundColor: 'rgba(255,255,255,0.3)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center'
+            }}
+          >
+            {Icons[event.icon] ? (
+              React.createElement(Icons[event.icon], { fontSize: 'small' })
+            ) : (
+              <span style={{ fontSize: '1rem' }}>{event.icon}</span>
+            )}
+          </Box>
+        )}
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5 }}>
-            <Typography 
+            <Typography
               variant="subtitle1" 
               sx={{ 
                 fontWeight: 700, 

--- a/client/src/components/calendar/IconPickerDialog.js
+++ b/client/src/components/calendar/IconPickerDialog.js
@@ -11,19 +11,25 @@ import {
 import * as Icons from '@mui/icons-material';
 
 const emojiList = [
-  '😀','😁','😂','😊','😍','🤔','😎','🎉','🎂','🍕','🍔','🍻','🎵','🏃','⭐','🔥','💻','📚','✈️','🚀'
+  '😀','😁','😂','😅','😊','😍','🤔','😎','🥳','🎉','🎁','🎂','🍕','🍔','🍣','🍜',
+  '🍻','🍺','☕','🎵','🎸','🎮','🏃','🚴','⚽','🏀','⭐','🌟','🌈','🔥','💻','📱',
+  '📚','🎓','✈️','🚀','🚗','🏡','🐶','🐱'
 ];
 
 const IconPickerDialog = ({ open, onClose, onSelect }) => {
   const [tab, setTab] = useState(0);
-  const iconNames = Object.keys(Icons);
+  const iconNames = [
+    'Home','Work','School','Star','CheckCircle','Event','Alarm','Flight',
+    'DirectionsRun','MusicNote','Restaurant','SportsEsports','ShoppingCart',
+    'Pets','Face','ThumbUp','Group','Laptop','Book','TravelExplore'
+  ];
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>Select Icon</DialogTitle>
       <Tabs value={tab} onChange={(e,v)=>setTab(v)} centered>
-        <Tab label="Icons" />
-        <Tab label="Emoji" />
+        <Tab label="icons" />
+        <Tab label="emoji" />
       </Tabs>
       <DialogContent dividers>
         {tab === 0 ? (
@@ -40,8 +46,15 @@ const IconPickerDialog = ({ open, onClose, onSelect }) => {
         ) : (
           <Box sx={{ display:'flex', flexWrap:'wrap', gap:1, maxHeight:300, overflowY:'auto' }}>
             {emojiList.map((emo) => (
-              <IconButton key={emo} onClick={() => { onSelect(emo); onClose(); }}>
-                <span style={{ fontSize: '24px' }}>{emo}</span>
+              <IconButton
+                key={emo}
+                onClick={() => {
+                  onSelect(emo);
+                  onClose();
+                }}
+                sx={{ color: 'initial' }}
+              >
+                <span style={{ fontSize: '24px', color: 'initial' }}>{emo}</span>
               </IconButton>
             ))}
           </Box>


### PR DESCRIPTION
## Summary
- align event icons beside titles
- keep emoji colors intact by removing grey tint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b5ad3372c83258b72eb55950eb7fe