### PR TITLE
Improve icon selection UI

### DIFF
--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -5,6 +5,7 @@ import {
   DialogContent,
   DialogActions,
   Button,
+  IconButton,
   TextField,
   Box,
   FormControl,
@@ -30,10 +31,11 @@ const AddEventDialog = ({
   userPreferences,
   darkMode
 }) => {
-  const [iconDialogOpen, setIconDialogOpen] = useState(false);
+  const [iconAnchorEl, setIconAnchorEl] = useState(null);
 
   const handleIconSelect = (icon) => {
     setNewEvent({ ...newEvent, icon });
+    setIconAnchorEl(null);
   };
   return (
     <Dialog 
@@ -58,27 +60,50 @@ const AddEventDialog = ({
         {dialogError && (
           <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
         )}
-        <FormControl component="fieldset" sx={{ mb: 2, width: '100%' }}>
-          <FormLabel component="legend" sx={{ fontFamily: 'Nunito, sans-serif' }}>Event Time</FormLabel>
-          <RadioGroup
-            row
-            value={newEvent.section}
-            onChange={(e) => setNewEvent({ ...newEvent, section: e.target.value })}
-          >
-            <FormControlLabel
-              value="day"
-              control={<Radio />}
-              label="Day"
-              sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
-            />
-            <FormControlLabel
-              value="evening"
-              control={<Radio />}
-              label="Evening"
-              sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
-            />
-          </RadioGroup>
-        </FormControl>
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+          <IconButton
+            onClick={(e) => setIconAnchorEl(e.currentTarget)}
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: '50%',
+            backgroundColor: darkMode ? '#757575' : '#ccc',
+            color: darkMode ? '#fff' : '#333',
+            mr: 2
+          }}
+        >
+            {newEvent.icon ? (
+              Icons[newEvent.icon] ? (
+                React.createElement(Icons[newEvent.icon])
+              ) : (
+                <span>{newEvent.icon}</span>
+              )
+            ) : (
+              <Icons.Add />
+            )}
+          </IconButton>
+          <FormControl component="fieldset" sx={{ width: '100%' }}>
+            <FormLabel component="legend" sx={{ fontFamily: 'Nunito, sans-serif' }}>Event Time</FormLabel>
+            <RadioGroup
+              row
+              value={newEvent.section}
+              onChange={(e) => setNewEvent({ ...newEvent, section: e.target.value })}
+            >
+              <FormControlLabel
+                value="day"
+                control={<Radio />}
+                label="Day"
+                sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
+              />
+              <FormControlLabel
+                value="evening"
+                control={<Radio />}
+                label="Evening"
+                sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
+              />
+            </RadioGroup>
+          </FormControl>
+        </Box>
         <TextField
           autoFocus
           margin="dense"
@@ -124,39 +149,6 @@ const AddEventDialog = ({
             sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
           }}
         />
-        <Button
-          variant="outlined"
-          onClick={() => setIconDialogOpen(true)}
-          sx={{
-            mt: 2,
-            textTransform: 'none',
-            fontFamily: 'Nunito, sans-serif'
-          }}
-        >
-          {newEvent.icon ? 'Change Icon' : 'Select Icon'}
-        </Button>
-        {newEvent.icon && (
-          <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-            <Box
-              sx={{
-                width: 48,
-                height: 48,
-                borderRadius: '50%',
-                backgroundColor: darkMode ? '#757575' : '#eee',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 32
-              }}
-            >
-              {Icons[newEvent.icon] ? (
-                React.createElement(Icons[newEvent.icon])
-              ) : (
-                <span>{newEvent.icon}</span>
-              )}
-            </Box>
-          </Box>
-        )}
       </DialogContent>
       <DialogActions>
         <Button 
@@ -190,9 +182,11 @@ const AddEventDialog = ({
         </Button>
       </DialogActions>
       <IconPickerDialog
-        open={iconDialogOpen}
-        onClose={() => setIconDialogOpen(false)}
+        anchorEl={iconAnchorEl}
+        onClose={() => setIconAnchorEl(null)}
         onSelect={handleIconSelect}
+        userColor={userPreferences.color}
+        darkMode={darkMode}
       />
     </Dialog>
   );

--- a/client/src/components/calendar/IconPickerDialog.js
+++ b/client/src/components/calendar/IconPickerDialog.js
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
+  Popover,
   Tabs,
   Tab,
   Box,
-  IconButton
+  IconButton,
+  Typography
 } from '@mui/material';
 import * as Icons from '@mui/icons-material';
+import { createPastelColor, createDarkPastelColor, getTextColor } from './colorUtils';
 
 const emojiList = [
   '📅', '⏰', '🎉', '🎂', '🎁', '🎈', '🔥','🪅', '🎊',
@@ -20,7 +20,7 @@ const emojiList = [
   '🚗', '✈️', '🚌', '🏥', '🏫', '🏛️', '⛪', '🛒', '🧳', '🏠',
 ];
 
-const IconPickerDialog = ({ open, onClose, onSelect }) => {
+const IconPickerDialog = ({ anchorEl, onClose, onSelect, userColor, darkMode }) => {
   const [tab, setTab] = useState(0);
   const iconNames = [
   'Event', 'Schedule', 'Celebration', 'Cake', 'MusicNote', 'Headphones', 'Mic', 'Movie',
@@ -34,27 +34,64 @@ const IconPickerDialog = ({ open, onClose, onSelect }) => {
   'LocalHospital', 'AccountBalance', 'Church', 'ShoppingCart', 'Luggage', 'Home'
   ];
 
+  const open = Boolean(anchorEl);
+  const bgColor = darkMode ? createDarkPastelColor(userColor) : createPastelColor(userColor);
+  const textColor = darkMode ? getTextColor(bgColor) : '#333';
+
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Select Icon</DialogTitle>
-      <Tabs value={tab} onChange={(e,v)=>setTab(v)} centered>
-        <Tab label="icons" />
-        <Tab label="emoji" />
+    <Popover
+      open={open}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      PaperProps={{
+        sx: {
+          backgroundColor: bgColor,
+          color: textColor,
+          p: 2,
+          fontFamily: 'Nunito, sans-serif',
+          maxWidth: 320,
+          borderRadius: 6,
+        }
+      }}
+    >
+      <Tabs
+        value={tab}
+        onChange={(e, v) => setTab(v)}
+        centered
+        textColor="inherit"
+        TabIndicatorProps={{ sx: { backgroundColor: textColor } }}
+      >
+        <Tab label="icons" sx={{ textTransform: 'lowercase', fontFamily: 'Nunito, sans-serif', color: textColor }} />
+        <Tab label="emoji" sx={{ textTransform: 'lowercase', fontFamily: 'Nunito, sans-serif', color: textColor }} />
       </Tabs>
-      <DialogContent dividers>
+      <Box sx={{ mt: 1 }}>
         {tab === 0 ? (
-          <Box sx={{ display:'flex', flexWrap:'wrap', gap:1, maxHeight:300, overflowY:'auto' }}>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, maxHeight: 300, overflowY: 'auto' }}>
             {iconNames.map((name) => {
               const IconComp = Icons[name];
               return (
-                <IconButton key={name} onClick={() => { onSelect(name); onClose(); }}>
+                <IconButton
+                  key={name}
+                  onClick={() => {
+                    onSelect(name);
+                    onClose();
+                  }}
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: '50%',
+                    backgroundColor: darkMode ? '#757575' : '#ccc',
+                    color: darkMode ? '#fff' : '#333',
+                  }}
+                >
                   <IconComp />
                 </IconButton>
               );
             })}
           </Box>
         ) : (
-          <Box sx={{ display:'flex', flexWrap:'wrap', gap:1, maxHeight:300, overflowY:'auto' }}>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, maxHeight: 300, overflowY: 'auto' }}>
             {emojiList.map((emo) => (
               <IconButton
                 key={emo}
@@ -62,15 +99,21 @@ const IconPickerDialog = ({ open, onClose, onSelect }) => {
                   onSelect(emo);
                   onClose();
                 }}
-                sx={{ color: 'initial' }}
+                sx={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: '50%',
+                  backgroundColor: darkMode ? '#757575' : '#ccc',
+                  color: darkMode ? '#fff' : '#333',
+                }}
               >
-                <span style={{ fontSize: '24px', color: 'initial' }}>{emo}</span>
+                <span style={{ fontSize: '24px' }}>{emo}</span>
               </IconButton>
             ))}
           </Box>
         )}
-      </DialogContent>
-    </Dialog>
+      </Box>
+    </Popover>
   );
 };
 


### PR DESCRIPTION
## Summary
- move icon selection button next to Event Time controls
- show icon picker in a popover anchored to the new button
- style picker title and tabs with Nunito and lowercase labels
- tint picker background with user's color for readability
- keep popover compact and style icons in circular buttons
- darken text and icon buttons in light mode for better contrast
- remove "Select Icon" heading and round the popover corners more

## Testing
- `npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684b89f1c1bc832590c764507f460c91