### PR TITLE
Fix unused import causing linter error

### DIFF
--- a/client/src/components/calendar/IconPickerDialog.js
+++ b/client/src/components/calendar/IconPickerDialog.js
@@ -5,7 +5,6 @@ import {
   Tab,
   Box,
   IconButton,
-  Typography
 } from '@mui/material';
 import * as Icons from '@mui/icons-material';
 import { createPastelColor, createDarkPastelColor, getTextColor } from './colorUtils';


### PR DESCRIPTION
## Summary
- remove unused `Typography` import in `IconPickerDialog`

## Testing
- `npm test --prefix client --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b97ef82308325882f2b1ba2da1fc5