### PR TITLE
Implement event editing

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import * as Icons from '@mui/icons-material';
 import { createHighlightColor, getTextColor, isWeekend } from './colorUtils';
 
@@ -20,6 +21,7 @@ const DayColumn = ({
   handleDayClick,
   handleEventClick,
   handleDelete,
+  handleEdit,
   handleJoin,
   isUserJoining,
   formatJoiners,
@@ -162,7 +164,7 @@ const DayColumn = ({
                   },
                   className: 'event-paper',
                   '&:hover .time-box': {
-                    right: { xs: isUserJoining(a) ? '140px' : '102px', sm: isUserJoining(a) ? '110px' : '72px' }
+                    right: { xs: isUserJoining(a) ? '180px' : '142px', sm: isUserJoining(a) ? '150px' : '112px' }
                   },
                   '&:hover .event-actions': {
                     opacity: { xs: 1, sm: 1 }
@@ -230,7 +232,7 @@ const DayColumn = ({
                             transition: { xs: 'none', sm: 'right 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 2,
                             pointerEvents: 'none',
-                            right: isMobile ? (isUserJoining(a) ? '140px' : '102px') : (activeEventId === a._id ? (isUserJoining(a) ? '110px' : '72px') : 0)
+                            right: isMobile ? (isUserJoining(a) ? '180px' : '142px') : (activeEventId === a._id ? (isUserJoining(a) ? '150px' : '112px') : 0)
                           }}
                           className="time-box"
                         >
@@ -282,6 +284,29 @@ const DayColumn = ({
                             ) : (
                               'Join'
                             )}
+                          </IconButton>
+                          <IconButton
+                            size="small"
+                            sx={{
+                              color: getTextColor(a.color),
+                              backgroundColor: 'rgba(255,255,255,0.2)',
+                              '&:hover': {
+                                backgroundColor: 'rgba(255,255,255,0.3)'
+                              },
+                              height: { xs: '36px', sm: '24px' },
+                              width: { xs: '36px', sm: '24px' },
+                              borderRadius: '12px',
+                              backdropFilter: 'blur(4px)',
+                              '& .MuiSvgIcon-root': {
+                                fontSize: { xs: '1.25rem', sm: '1rem' }
+                              }
+                            }}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleEdit(a);
+                            }}
+                          >
+                            <EditIcon fontSize="small" />
                           </IconButton>
                           <IconButton
                             size="small"
@@ -396,7 +421,7 @@ const DayColumn = ({
                     },
                     className: 'event-paper',
                     '&:hover .time-box': {
-                      right: { xs: isUserJoining(a) ? '140px' : '102px', sm: isUserJoining(a) ? '110px' : '72px' }
+                      right: { xs: isUserJoining(a) ? '180px' : '142px', sm: isUserJoining(a) ? '150px' : '112px' }
                     },
                     '&:hover .event-actions': {
                       opacity: { xs: 1, sm: 1 }
@@ -464,7 +489,7 @@ const DayColumn = ({
                               transition: { xs: 'none', sm: 'right 0.3s cubic-bezier(0.4,0,0.2,1)' },
                               zIndex: 2,
                               pointerEvents: 'none',
-                              right: isMobile ? (isUserJoining(a) ? '140px' : '102px') : (activeEventId === a._id ? (isUserJoining(a) ? '110px' : '72px') : 0)
+                              right: isMobile ? (isUserJoining(a) ? '180px' : '142px') : (activeEventId === a._id ? (isUserJoining(a) ? '150px' : '112px') : 0)
                             }}
                             className="time-box"
                           >
@@ -535,6 +560,29 @@ const DayColumn = ({
                               }}
                               onClick={(e) => {
                                 e.stopPropagation();
+                                handleEdit(a);
+                              }}
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                            <IconButton
+                              size="small"
+                              sx={{
+                                color: getTextColor(a.color),
+                                backgroundColor: 'rgba(255,255,255,0.2)',
+                                '&:hover': {
+                                  backgroundColor: 'rgba(255,255,255,0.3)'
+                                },
+                                height: { xs: '36px', sm: '24px' },
+                                width: { xs: '36px', sm: '24px' },
+                                borderRadius: '12px',
+                                backdropFilter: 'blur(4px)',
+                                '& .MuiSvgIcon-root': {
+                                  fontSize: { xs: '1.25rem', sm: '1rem' }
+                                }
+                              }}
+                              onClick={(e) => {
+                                e.stopPropagation();
                                 handleDelete(a._id);
                               }}
                             >
@@ -582,3 +630,4 @@ const DayColumn = ({
 };
 
 export default DayColumn;
+

--- a/client/src/components/calendar/EditEventDialog.js
+++ b/client/src/components/calendar/EditEventDialog.js
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  IconButton,
+  TextField,
+  Box,
+  FormControl,
+  FormLabel,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+  Alert
+} from '@mui/material';
+import { getTextColor } from './colorUtils';
+import IconPickerDialog from './IconPickerDialog';
+import * as Icons from '@mui/icons-material';
+
+const EditEventDialog = ({
+  open,
+  onClose,
+  selectedDate,
+  newEvent,
+  setNewEvent,
+  handleSubmit,
+  handleKeyPress,
+  dialogError,
+  userPreferences,
+  darkMode
+}) => {
+  const [iconAnchorEl, setIconAnchorEl] = useState(null);
+
+  const handleIconSelect = (icon) => {
+    setNewEvent({ ...newEvent, icon });
+    setIconAnchorEl(null);
+  };
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          borderRadius: 4,
+          fontFamily: 'Nunito, sans-serif',
+          margin: { xs: '16px', sm: '32px' },
+          position: { xs: 'absolute', sm: 'relative' },
+          top: { xs: '10%', sm: 'auto' },
+          backgroundColor: darkMode ? '#616161' : 'white',
+          color: darkMode ? '#fff' : 'inherit'
+        }
+      }}
+    >
+      <DialogTitle sx={{ fontFamily: 'Nunito, sans-serif', fontWeight: 600 }}>
+        Edit event
+      </DialogTitle>
+      <DialogContent>
+        {dialogError && (
+          <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
+        )}
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+          <IconButton
+            onClick={(e) => setIconAnchorEl(e.currentTarget)}
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: '50%',
+              backgroundColor: darkMode ? '#757575' : '#ccc',
+              color: darkMode ? '#fff' : '#333',
+              mr: 2
+            }}
+          >
+            {newEvent.icon ? (
+              Icons[newEvent.icon] ? (
+                React.createElement(Icons[newEvent.icon])
+              ) : (
+                <span>{newEvent.icon}</span>
+              )
+            ) : (
+              <Icons.Edit />
+            )}
+          </IconButton>
+          <FormControl component="fieldset" sx={{ width: '100%' }}>
+            <FormLabel component="legend" sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}>Event Time</FormLabel>
+            <RadioGroup
+              row
+              value={newEvent.section}
+              onChange={(e) => setNewEvent({ ...newEvent, section: e.target.value })}
+            >
+              <FormControlLabel
+                value="day"
+                control={<Radio />}
+                label="Day"
+                sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
+              />
+              <FormControlLabel
+                value="evening"
+                control={<Radio />}
+                label="Evening"
+                sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
+              />
+            </RadioGroup>
+          </FormControl>
+        </Box>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Time"
+          fullWidth
+          value={newEvent.timeSlot}
+          onChange={(e) => setNewEvent({ ...newEvent, timeSlot: e.target.value })}
+          onKeyPress={handleKeyPress}
+          sx={{ mb: 2 }}
+          placeholder={selectedDate ? (newEvent.section === 'evening' ? '6-7pm' : '9-5') : ''}
+          InputProps={{
+            sx: {
+              fontFamily: 'Nunito, sans-serif',
+              backgroundColor: darkMode ? '#757575' : 'white',
+              color: darkMode ? '#fff' : 'inherit',
+              '& fieldset': {
+                borderColor: darkMode ? '#bbb' : 'inherit'
+              }
+            }
+          }}
+          InputLabelProps={{
+            sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
+          }}
+        />
+        <TextField
+          margin="dense"
+          label="Location / Event"
+          fullWidth
+          value={newEvent.location}
+          onChange={(e) => setNewEvent({ ...newEvent, location: e.target.value })}
+          onKeyPress={handleKeyPress}
+          InputProps={{
+            sx: {
+              fontFamily: 'Nunito, sans-serif',
+              backgroundColor: darkMode ? '#757575' : 'white',
+              color: darkMode ? '#fff' : 'inherit',
+              '& fieldset': {
+                borderColor: darkMode ? '#bbb' : 'inherit'
+              }
+            }
+          }}
+          InputLabelProps={{
+            sx: { fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button
+          onClick={onClose}
+          sx={{
+            textTransform: 'none',
+            fontFamily: 'Nunito, sans-serif',
+            fontWeight: 600
+          }}
+        >
+          cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          variant="contained"
+          sx={{
+            backgroundColor: userPreferences.color,
+            color: getTextColor(userPreferences.color),
+            textTransform: 'none',
+            borderRadius: 2,
+            fontFamily: 'Nunito, sans-serif',
+            fontWeight: 600,
+            transition: 'all 0.5s ease',
+            '&:hover': {
+              backgroundColor: userPreferences.color,
+              opacity: 0.9
+            }
+          }}
+        >
+          save
+        </Button>
+      </DialogActions>
+      <IconPickerDialog
+        anchorEl={iconAnchorEl}
+        onClose={() => setIconAnchorEl(null)}
+        onSelect={handleIconSelect}
+        userColor={userPreferences.color}
+        darkMode={darkMode}
+      />
+    </Dialog>
+  );
+};
+
+export default EditEventDialog;
+

--- a/server.js
+++ b/server.js
@@ -91,6 +91,22 @@ app.post('/api/availability', async (req, res) => {
   }
 });
 
+app.put('/api/availability/:id', async (req, res) => {
+  try {
+    const updated = await Availability.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
+    if (!updated) {
+      return res.status(404).json({ message: 'Event not found' });
+    }
+    res.json(updated);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
 app.delete('/api/availability/:id', async (req, res) => {
   try {
     await Availability.findByIdAndDelete(req.params.id);


### PR DESCRIPTION
## Summary
- add `/api/availability/:id` PUT route
- create `EditEventDialog` for modifying events
- support opening and closing edit dialog in `Calendar`
- surface edit buttons in day columns and adjust animation offsets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68504783876c8325a6a8e611efd49c4b