### PR TITLE
Fix time box overlap with names

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -204,7 +204,9 @@ const DayColumn = ({
                             wordBreak: 'break-word',
                             lineHeight: 1.2,
                             flex: 1,
-                            pr: 1
+                            pr: 1,
+                            position: 'relative',
+                            zIndex: 3
                           }}
                         >
                           {a.name}
@@ -215,7 +217,7 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '150px' : '112px' },
+                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '100px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
                             backgroundColor: 'rgba(255,255,255,0.2)',
@@ -472,7 +474,9 @@ const DayColumn = ({
                               wordBreak: 'break-word',
                               lineHeight: 1.2,
                               flex: 1,
-                              pr: 1
+                              pr: 1,
+                              position: 'relative',
+                              zIndex: 3
                             }}
                           >
                             {a.name}
@@ -483,7 +487,7 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '150px' : '112px' },
+                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '100px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
                             backgroundColor: 'rgba(255,255,255,0.2)',


### PR DESCRIPTION
## Summary
- keep event names above the time box overlay
- shrink time box width so it doesn't cover names

## Testing
- `npm install` (in `client`)
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6851a5c0d8788325a3f623bf86847db1