### PR TITLE
Update calendar styles

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -224,7 +224,7 @@ const DayColumn = ({
                             minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '84px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
-                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            backgroundColor: 'rgba(255,255,255,0.235)',
                             backdropFilter: 'blur(4px)',
                             color: getTextColor(a.color),
                             display: 'flex',
@@ -286,7 +286,7 @@ const DayColumn = ({
                               gap: 0.5,
                               fontSize: { xs: '0.875rem', sm: '0.75rem' },
                               padding: { xs: '0 12px', sm: '0 8px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)'
                             }}
                             onClick={(e) => {
@@ -313,7 +313,7 @@ const DayColumn = ({
                               },
                               height: { xs: '36px', sm: '24px' },
                               width: { xs: '36px', sm: '24px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)',
                               '& .MuiSvgIcon-root': {
                                 fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -336,7 +336,7 @@ const DayColumn = ({
                               },
                               height: { xs: '36px', sm: '24px' },
                               width: { xs: '36px', sm: '24px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)',
                               '& .MuiSvgIcon-root': {
                                 fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -498,7 +498,7 @@ const DayColumn = ({
                             minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '84px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
-                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            backgroundColor: 'rgba(255,255,255,0.235)',
                             backdropFilter: 'blur(4px)',
                             color: getTextColor(a.color),
                             display: 'flex',
@@ -560,7 +560,7 @@ const DayColumn = ({
                                 gap: 0.5,
                                 fontSize: { xs: '0.875rem', sm: '0.75rem' },
                                 padding: { xs: '0 12px', sm: '0 8px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)'
                               }}
                               onClick={(e) => {
@@ -587,7 +587,7 @@ const DayColumn = ({
                                 },
                                 height: { xs: '36px', sm: '24px' },
                                 width: { xs: '36px', sm: '24px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)',
                                 '& .MuiSvgIcon-root': {
                                   fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -610,7 +610,7 @@ const DayColumn = ({
                                 },
                                 height: { xs: '36px', sm: '24px' },
                                 width: { xs: '36px', sm: '24px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)',
                                 '& .MuiSvgIcon-root': {
                                   fontSize: { xs: '1.25rem', sm: '1rem' }

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -86,7 +86,7 @@ const Event = memo(({
                 minWidth: '60px',
                 height: '40px',
                 borderRadius: '8px',
-                backgroundColor: 'rgba(255,255,255,0.2)',
+                backgroundColor: 'rgba(255,255,255,0.235)',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',


### PR DESCRIPTION
## Summary
- match desktop event action buttons to mobile style with 8px radius
- unify time box opacity with buttons

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6851af418e08832597ba5adf965c8d5a