### PR TITLE
Update calendar styles

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -221,17 +221,17 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '84px' },
+                            minWidth: { xs: '78px', sm: isUserJoining(a) ? '120px' : '78px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
-                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            backgroundColor: 'rgba(255,255,255,0.235)',
                             backdropFilter: 'blur(4px)',
                             color: getTextColor(a.color),
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
                             flexShrink: 0,
-                            padding: { xs: '0 12px', sm: '0 8px' },
+                            padding: '0 8px',
                             fontWeight: 600,
                             fontSize: { xs: '0.875rem', sm: '0.875rem' },
                             fontFamily: 'Nunito, sans-serif',
@@ -285,8 +285,9 @@ const DayColumn = ({
                               justifyContent: 'flex-start',
                               gap: 0.5,
                               fontSize: { xs: '0.875rem', sm: '0.75rem' },
+                              fontFamily: 'Nunito, sans-serif',
                               padding: { xs: '0 12px', sm: '0 8px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)'
                             }}
                             onClick={(e) => {
@@ -313,7 +314,7 @@ const DayColumn = ({
                               },
                               height: { xs: '36px', sm: '24px' },
                               width: { xs: '36px', sm: '24px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)',
                               '& .MuiSvgIcon-root': {
                                 fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -336,7 +337,7 @@ const DayColumn = ({
                               },
                               height: { xs: '36px', sm: '24px' },
                               width: { xs: '36px', sm: '24px' },
-                              borderRadius: '12px',
+                              borderRadius: '8px',
                               backdropFilter: 'blur(4px)',
                               '& .MuiSvgIcon-root': {
                                 fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -495,17 +496,17 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            minWidth: { xs: '80px', sm: isUserJoining(a) ? '120px' : '84px' },
+                            minWidth: { xs: '78px', sm: isUserJoining(a) ? '120px' : '78px' },
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
-                            backgroundColor: 'rgba(255,255,255,0.2)',
+                            backgroundColor: 'rgba(255,255,255,0.235)',
                             backdropFilter: 'blur(4px)',
                             color: getTextColor(a.color),
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
                             flexShrink: 0,
-                            padding: { xs: '0 12px', sm: '0 8px' },
+                            padding: '0 8px',
                             fontWeight: 600,
                             fontSize: { xs: '0.875rem', sm: '0.875rem' },
                             fontFamily: 'Nunito, sans-serif',
@@ -559,8 +560,9 @@ const DayColumn = ({
                                 justifyContent: 'flex-start',
                                 gap: 0.5,
                                 fontSize: { xs: '0.875rem', sm: '0.75rem' },
+                                fontFamily: 'Nunito, sans-serif',
                                 padding: { xs: '0 12px', sm: '0 8px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)'
                               }}
                               onClick={(e) => {
@@ -587,7 +589,7 @@ const DayColumn = ({
                                 },
                                 height: { xs: '36px', sm: '24px' },
                                 width: { xs: '36px', sm: '24px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)',
                                 '& .MuiSvgIcon-root': {
                                   fontSize: { xs: '1.25rem', sm: '1rem' }
@@ -610,7 +612,7 @@ const DayColumn = ({
                                 },
                                 height: { xs: '36px', sm: '24px' },
                                 width: { xs: '36px', sm: '24px' },
-                                borderRadius: '12px',
+                                borderRadius: '8px',
                                 backdropFilter: 'blur(4px)',
                                 '& .MuiSvgIcon-root': {
                                   fontSize: { xs: '1.25rem', sm: '1rem' }

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -83,10 +83,10 @@ const Event = memo(({
             </Box>
             <Tooltip title={event.timeSlot} arrow placement="top">
               <Box sx={{
-                minWidth: '60px',
+                minWidth: '78px',
                 height: '40px',
                 borderRadius: '8px',
-                backgroundColor: 'rgba(255,255,255,0.2)',
+                backgroundColor: 'rgba(255,255,255,0.235)',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
@@ -166,6 +166,7 @@ const Event = memo(({
             justifyContent: 'flex-start',
             gap: 0.5,
             fontSize: '0.75rem',
+            fontFamily: 'Nunito, sans-serif',
             padding: '4px 8px',
             borderRadius: '12px'
           }}


### PR DESCRIPTION
## Summary
- match desktop event action buttons to mobile style with 8px radius
- unify time box opacity with buttons
- shrink time box width to 78px and set join buttons to Nunito font

## Testing
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6851af418e08832597ba5adf965c8d5a