### PR TITLE
Add desktop error tooltips

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -13,6 +13,7 @@ import { createPastelColor, createDarkPastelColor, COLORS } from './calendar/col
 import UserPreferences from './calendar/UserPreferences';
 import AddEventDialog from './calendar/AddEventDialog';
 import EditEventDialog from './calendar/EditEventDialog';
+import ErrorTooltip from './ErrorTooltip';
 
 import DayColumn from "./calendar/DayColumn";
 // Function to convert hex to RGB
@@ -339,9 +340,10 @@ const Calendar = () => {
         </Typography>
       </Box>
       
-      {error && (
+      {error && isMobile && (
         <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{error}</Alert>
       )}
+      {!isMobile && <ErrorTooltip message={error} />}
 
       <UserPreferences
         userPreferences={userPreferences}
@@ -413,6 +415,7 @@ const Calendar = () => {
         dialogError={dialogError}
         userPreferences={userPreferences}
         darkMode={darkMode}
+        isMobile={isMobile}
       />
       <EditEventDialog
         open={openEditDialog}
@@ -425,6 +428,7 @@ const Calendar = () => {
         dialogError={dialogError}
         userPreferences={userPreferences}
         darkMode={darkMode}
+        isMobile={isMobile}
       />
     </Box>
   );

--- a/client/src/components/ErrorTooltip.js
+++ b/client/src/components/ErrorTooltip.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip } from '@mui/material';
+
+const ErrorTooltip = ({ message }) => {
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handleMouseMove = (e) => {
+      setPosition({ x: e.clientX + 12, y: e.clientY + 12 });
+    };
+
+    if (message) {
+      window.addEventListener('mousemove', handleMouseMove);
+    }
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+    };
+  }, [message]);
+
+  if (!message) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: position.x,
+        top: position.y,
+        pointerEvents: 'none',
+        zIndex: 1500,
+      }}
+    >
+      <Tooltip open title={message} placement="right" arrow>
+        <span />
+      </Tooltip>
+    </div>
+  );
+};
+
+ErrorTooltip.propTypes = {
+  message: PropTypes.string,
+};
+
+export default ErrorTooltip;

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -19,6 +19,7 @@ import {
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
 import * as Icons from '@mui/icons-material';
+import ErrorTooltip from '../ErrorTooltip';
 
 const AddEventDialog = ({
   open,
@@ -30,7 +31,8 @@ const AddEventDialog = ({
   handleKeyPress,
   dialogError,
   userPreferences,
-  darkMode
+  darkMode,
+  isMobile
 }) => {
   const [iconAnchorEl, setIconAnchorEl] = useState(null);
 
@@ -58,9 +60,10 @@ const AddEventDialog = ({
         What are your plans on {selectedDate?.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' })}?
       </DialogTitle>
       <DialogContent>
-        {dialogError && (
+        {dialogError && isMobile && (
           <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
         )}
+        {!isMobile && <ErrorTooltip message={dialogError} />}
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton
             onClick={(e) => setIconAnchorEl(e.currentTarget)}
@@ -211,6 +214,7 @@ AddEventDialog.propTypes = {
     color: PropTypes.string.isRequired,
   }).isRequired,
   darkMode: PropTypes.bool.isRequired,
+  isMobile: PropTypes.bool.isRequired,
 };
 
 export default AddEventDialog;

--- a/client/src/components/calendar/EditEventDialog.js
+++ b/client/src/components/calendar/EditEventDialog.js
@@ -19,6 +19,7 @@ import {
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
 import * as Icons from '@mui/icons-material';
+import ErrorTooltip from '../ErrorTooltip';
 
 const EditEventDialog = ({
   open,
@@ -30,7 +31,8 @@ const EditEventDialog = ({
   handleKeyPress,
   dialogError,
   userPreferences,
-  darkMode
+  darkMode,
+  isMobile
 }) => {
   const [iconAnchorEl, setIconAnchorEl] = useState(null);
 
@@ -58,9 +60,10 @@ const EditEventDialog = ({
         Edit event
       </DialogTitle>
       <DialogContent>
-        {dialogError && (
+        {dialogError && isMobile && (
           <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
         )}
+        {!isMobile && <ErrorTooltip message={dialogError} />}
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton
             onClick={(e) => setIconAnchorEl(e.currentTarget)}
@@ -211,6 +214,7 @@ EditEventDialog.propTypes = {
     color: PropTypes.string.isRequired,
   }).isRequired,
   darkMode: PropTypes.bool.isRequired,
+  isMobile: PropTypes.bool.isRequired,
 };
 
 export default EditEventDialog;


### PR DESCRIPTION
## Summary
- show tooltip next to cursor for errors on desktop
- pass `isMobile` flag into event dialogs
- include tooltip for dialog errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851b6ffdb80832589533cabad9f63b7