### PR TITLE
Add desktop error tooltips

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -13,6 +13,7 @@ import { createPastelColor, createDarkPastelColor, COLORS } from './calendar/col
 import UserPreferences from './calendar/UserPreferences';
 import AddEventDialog from './calendar/AddEventDialog';
 import EditEventDialog from './calendar/EditEventDialog';
+import ErrorTooltip from './ErrorTooltip';
 
 import DayColumn from "./calendar/DayColumn";
 // Function to convert hex to RGB
@@ -100,6 +101,18 @@ const Calendar = () => {
       setError(null);
     }
   }, [userPreferences.name, error, setError]);
+
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => setError(null), 3000);
+    return () => clearTimeout(timer);
+  }, [error, setError]);
+
+  useEffect(() => {
+    if (!dialogError) return;
+    const timer = setTimeout(() => setDialogError(null), 3000);
+    return () => clearTimeout(timer);
+  }, [dialogError]);
 
   const handleDayClick = useCallback((date, section) => {
     if (!userPreferences.name) {
@@ -339,9 +352,10 @@ const Calendar = () => {
         </Typography>
       </Box>
       
-      {error && (
+      {error && isMobile && (
         <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{error}</Alert>
       )}
+      {!isMobile && <ErrorTooltip message={error} />}
 
       <UserPreferences
         userPreferences={userPreferences}
@@ -413,6 +427,7 @@ const Calendar = () => {
         dialogError={dialogError}
         userPreferences={userPreferences}
         darkMode={darkMode}
+        isMobile={isMobile}
       />
       <EditEventDialog
         open={openEditDialog}
@@ -425,6 +440,7 @@ const Calendar = () => {
         dialogError={dialogError}
         userPreferences={userPreferences}
         darkMode={darkMode}
+        isMobile={isMobile}
       />
     </Box>
   );

--- a/client/src/components/ErrorTooltip.js
+++ b/client/src/components/ErrorTooltip.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Tooltip, Fade } from '@mui/material';
+import useMousePosition from '../hooks/useMousePosition';
+
+const ErrorTooltip = ({ message, duration = 3000 }) => {
+  const { x, y } = useMousePosition();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!message) return;
+    setOpen(true);
+    const timer = setTimeout(() => setOpen(false), duration);
+    return () => clearTimeout(timer);
+  }, [message, duration]);
+
+  if (!message && !open) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: x + 12,
+        top: y + 12,
+        pointerEvents: 'none',
+        zIndex: 1500,
+      }}
+    >
+      <Tooltip
+        open={open}
+        title={message}
+        placement="right"
+        arrow
+        TransitionComponent={Fade}
+      >
+        <span />
+      </Tooltip>
+    </div>
+  );
+};
+
+ErrorTooltip.propTypes = {
+  message: PropTypes.string,
+  duration: PropTypes.number,
+};
+
+export default ErrorTooltip;

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -19,6 +19,7 @@ import {
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
 import * as Icons from '@mui/icons-material';
+import ErrorTooltip from '../ErrorTooltip';
 
 const AddEventDialog = ({
   open,
@@ -30,7 +31,8 @@ const AddEventDialog = ({
   handleKeyPress,
   dialogError,
   userPreferences,
-  darkMode
+  darkMode,
+  isMobile
 }) => {
   const [iconAnchorEl, setIconAnchorEl] = useState(null);
 
@@ -58,9 +60,10 @@ const AddEventDialog = ({
         What are your plans on {selectedDate?.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' })}?
       </DialogTitle>
       <DialogContent>
-        {dialogError && (
+        {dialogError && isMobile && (
           <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
         )}
+        {!isMobile && <ErrorTooltip message={dialogError} />}
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton
             onClick={(e) => setIconAnchorEl(e.currentTarget)}
@@ -211,6 +214,7 @@ AddEventDialog.propTypes = {
     color: PropTypes.string.isRequired,
   }).isRequired,
   darkMode: PropTypes.bool.isRequired,
+  isMobile: PropTypes.bool.isRequired,
 };
 
 export default AddEventDialog;

--- a/client/src/components/calendar/EditEventDialog.js
+++ b/client/src/components/calendar/EditEventDialog.js
@@ -19,6 +19,7 @@ import {
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
 import * as Icons from '@mui/icons-material';
+import ErrorTooltip from '../ErrorTooltip';
 
 const EditEventDialog = ({
   open,
@@ -30,7 +31,8 @@ const EditEventDialog = ({
   handleKeyPress,
   dialogError,
   userPreferences,
-  darkMode
+  darkMode,
+  isMobile
 }) => {
   const [iconAnchorEl, setIconAnchorEl] = useState(null);
 
@@ -58,9 +60,10 @@ const EditEventDialog = ({
         Edit event
       </DialogTitle>
       <DialogContent>
-        {dialogError && (
+        {dialogError && isMobile && (
           <Alert severity="error" sx={{ mb: 2, fontFamily: 'Nunito, sans-serif' }}>{dialogError}</Alert>
         )}
+        {!isMobile && <ErrorTooltip message={dialogError} />}
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <IconButton
             onClick={(e) => setIconAnchorEl(e.currentTarget)}
@@ -211,6 +214,7 @@ EditEventDialog.propTypes = {
     color: PropTypes.string.isRequired,
   }).isRequired,
   darkMode: PropTypes.bool.isRequired,
+  isMobile: PropTypes.bool.isRequired,
 };
 
 export default EditEventDialog;

--- a/client/src/hooks/useMousePosition.js
+++ b/client/src/hooks/useMousePosition.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+const useMousePosition = () => {
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const update = (e) => {
+      setPosition({ x: e.clientX, y: e.clientY });
+    };
+    window.addEventListener('mousemove', update);
+    return () => window.removeEventListener('mousemove', update);
+  }, []);
+
+  return position;
+};
+
+export default useMousePosition;


### PR DESCRIPTION
## Summary
- show tooltip next to cursor for errors on desktop
- pass `isMobile` flag into event dialogs
- include tooltip for dialog errors
- ensure tooltip position follows mouse immediately and fades after 3s
- clear error states after 3 seconds to prevent sticky animations

## Testing
- `npm --prefix client install` *(to install dependencies)*
- `npm --prefix client test --silent` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6ffdb80832589533cabad9f63b7