### PR TITLE
Fix custom color activation

### DIFF
--- a/client/src/components/calendar/UserPreferences.js
+++ b/client/src/components/calendar/UserPreferences.js
@@ -66,7 +66,10 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
             ))}
             <Box
               component="label"
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setUserPreferences({ ...userPreferences, color: selectedColor });
+              }}
               sx={{
                 width: 32,
                 height: 32,


### PR DESCRIPTION
## Summary
- update UserPreferences so selecting custom color immediately applies current custom color when palette icon is clicked

## Testing
- `npm test` *(fails: no such script)*

------
https://chatgpt.com/codex/tasks/task_e_6854195418fc8325a71dc1a5e5f7be2d