### PR TITLE
Adjust width handling of time boxes

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -237,7 +237,7 @@ const DayColumn = ({
                             fontFamily: 'Nunito, sans-serif',
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
-                            textOverflow: 'ellipsis',
+                            maxWidth: '50%',
                             transition: { xs: 'none', sm: 'top 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 2,
                             pointerEvents: 'none',
@@ -264,6 +264,8 @@ const DayColumn = ({
                             right: 0,
                             display: 'flex',
                             gap: 0.5,
+                            flexWrap: 'wrap',
+                            maxWidth: '50%',
                             opacity: isMobile ? 1 : (activeEventId === a._id ? 1 : 0),
                             transition: { xs: 'none', sm: 'opacity 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 1,
@@ -512,7 +514,7 @@ const DayColumn = ({
                             fontFamily: 'Nunito, sans-serif',
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
-                            textOverflow: 'ellipsis',
+                            maxWidth: '50%',
                             transition: { xs: 'none', sm: 'top 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 2,
                             pointerEvents: 'none',
@@ -533,12 +535,14 @@ const DayColumn = ({
                           </Box>
                           <Box
                             className="event-actions"
-                            sx={{
+                          sx={{
                               position: 'absolute',
                               top: 0,
                               right: 0,
                               display: 'flex',
                               gap: 0.5,
+                              flexWrap: 'wrap',
+                              maxWidth: '50%',
                               opacity: isMobile ? 1 : (activeEventId === a._id ? 1 : 0),
                               transition: { xs: 'none', sm: 'opacity 0.3s cubic-bezier(0.4,0,0.2,1)' },
                               zIndex: 1,

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -91,15 +91,16 @@ const Event = memo(({
                 alignItems: 'center',
                 justifyContent: 'center',
                 flexShrink: 0,
-                padding: '0 8px'
+                padding: '0 8px',
+                maxWidth: '50%',
+                overflow: 'hidden'
               }}>
-                <Typography variant="body2" sx={{ 
+                <Typography variant="body2" sx={{
                   fontWeight: 600,
                   fontSize: '0.75rem',
                   fontFamily: 'Nunito, sans-serif',
                   whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis'
+                  overflow: 'hidden'
                 }}>
                   {event.timeSlot}
                 </Typography>
@@ -135,14 +136,16 @@ const Event = memo(({
           )}
         </Box>
       </Box>
-      <Box 
+      <Box
         className="event-actions"
-        sx={{ 
-          position: 'absolute', 
-          top: 8, 
+        sx={{
+          position: 'absolute',
+          top: 8,
           right: 8,
           display: 'flex',
           gap: 0.5,
+          flexWrap: 'wrap',
+          maxWidth: '50%',
           opacity: 0,
           transition: 'opacity 0.2s ease',
           backgroundColor: event.color,


### PR DESCRIPTION
## Summary
- limit time box width to half the event width
- wrap event action buttons when reaching that width

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68541a7c78b08325a0b376b4a38c49bf