### PR TITLE
Fix timebox width calculations

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Grid,
@@ -14,6 +14,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import * as Icons from '@mui/icons-material';
 import { createHighlightColor, getTextColor, isWeekend } from './colorUtils';
+import useElementWidth from '../../hooks/useElementWidth';
 
 const DayColumn = ({
   date,
@@ -31,6 +32,12 @@ const DayColumn = ({
   activeEventId,
   darkMode
 }) => {
+  const containerRef = useRef(null);
+  const width = useElementWidth(containerRef);
+  const half = width / 2;
+  const timeBoxWidth = half - 16;
+  const actionsMaxWidth = half - 8;
+  const shouldWrapActions = actionsMaxWidth < 120;
   const handleSectionClick = (section, e) => {
     if (!isMobile) {
       handleDayClick(date, section, e);
@@ -131,6 +138,7 @@ const DayColumn = ({
         <Divider sx={{ mb: 2 }} />
         {/* Day Section */}
         <Box
+          ref={containerRef}
           sx={{
             flex: 1,
             cursor: { xs: 'default', sm: 'pointer' },
@@ -221,7 +229,7 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            width: { xs: '78px', sm: isUserJoining(a) ? '120px' : '78px' },
+                            width: `${timeBoxWidth}px`,
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
                             backgroundColor: 'rgba(255,255,255,0.235)',
@@ -237,7 +245,7 @@ const DayColumn = ({
                             fontFamily: 'Nunito, sans-serif',
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
-                            maxWidth: 'calc(50% - 16px)',
+                            maxWidth: `${actionsMaxWidth}px`,
                             transition: { xs: 'none', sm: 'top 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 2,
                             pointerEvents: 'none',
@@ -264,8 +272,8 @@ const DayColumn = ({
                             right: 0,
                             display: 'flex',
                             gap: 0.5,
-                            flexWrap: 'wrap',
-                            maxWidth: 'calc(50% - 8px)',
+                            flexWrap: shouldWrapActions ? 'wrap' : 'nowrap',
+                            maxWidth: `${actionsMaxWidth}px`,
                             opacity: isMobile ? 1 : (activeEventId === a._id ? 1 : 0),
                             transition: { xs: 'none', sm: 'opacity 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 1,
@@ -498,7 +506,7 @@ const DayColumn = ({
                           sx={{
                             position: 'absolute',
                             top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                            width: { xs: '78px', sm: isUserJoining(a) ? '120px' : '78px' },
+                            width: `${timeBoxWidth}px`,
                             height: { xs: '36px', sm: '28px' },
                             borderRadius: '8px',
                             backgroundColor: 'rgba(255,255,255,0.235)',
@@ -514,7 +522,7 @@ const DayColumn = ({
                             fontFamily: 'Nunito, sans-serif',
                             whiteSpace: 'nowrap',
                             overflow: 'hidden',
-                            maxWidth: 'calc(50% - 16px)',
+                            maxWidth: `${actionsMaxWidth}px`,
                             transition: { xs: 'none', sm: 'top 0.3s cubic-bezier(0.4,0,0.2,1)' },
                             zIndex: 2,
                             pointerEvents: 'none',
@@ -541,8 +549,8 @@ const DayColumn = ({
                               right: 0,
                               display: 'flex',
                               gap: 0.5,
-                              flexWrap: 'wrap',
-                              maxWidth: 'calc(50% - 8px)',
+                              flexWrap: shouldWrapActions ? 'wrap' : 'nowrap',
+                              maxWidth: `${actionsMaxWidth}px`,
                               opacity: isMobile ? 1 : (activeEventId === a._id ? 1 : 0),
                               transition: { xs: 'none', sm: 'opacity 0.3s cubic-bezier(0.4,0,0.2,1)' },
                               zIndex: 1,

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useRef } from 'react';
 import { 
   Paper, 
   Typography, 
@@ -9,16 +9,25 @@ import {
 import DeleteIcon from '@mui/icons-material/Delete';
 import * as Icons from '@mui/icons-material';
 import { getTextColor } from './colorUtils';
+import useElementWidth from '../../hooks/useElementWidth';
 
 const Event = memo(({ 
-  event, 
-  onEventClick, 
-  onDelete, 
-  isUserJoining, 
-  formatJoiners 
+  event,
+  onEventClick,
+  onDelete,
+  isUserJoining,
+  formatJoiners
 }) => {
+  const paperRef = useRef(null);
+  const width = useElementWidth(paperRef);
+  const half = width / 2;
+  const timeBoxWidth = half - 16;
+  const actionsMaxWidth = half - 8;
+  const shouldWrapActions = actionsMaxWidth < 120;
+
   return (
     <Paper
+      ref={paperRef}
       sx={{
         p: 1.5,
         mb: 1.5,
@@ -83,7 +92,7 @@ const Event = memo(({
             </Box>
             <Tooltip title={event.timeSlot} arrow placement="top">
               <Box sx={{
-                width: '78px',
+                width: `${timeBoxWidth}px`,
                 height: '40px',
                 borderRadius: '8px',
                 backgroundColor: 'rgba(255,255,255,0.235)',
@@ -92,7 +101,7 @@ const Event = memo(({
                 justifyContent: 'center',
                 flexShrink: 0,
                 padding: '0 8px',
-                maxWidth: 'calc(50% - 16px)',
+                maxWidth: `${actionsMaxWidth}px`,
                 overflow: 'hidden'
               }}>
                 <Typography variant="body2" sx={{
@@ -144,8 +153,8 @@ const Event = memo(({
           right: 8,
           display: 'flex',
           gap: 0.5,
-          flexWrap: 'wrap',
-          maxWidth: 'calc(50% - 8px)',
+          flexWrap: shouldWrapActions ? 'wrap' : 'nowrap',
+          maxWidth: `${actionsMaxWidth}px`,
           opacity: 0,
           transition: 'opacity 0.2s ease',
           backgroundColor: event.color,

--- a/client/src/hooks/useElementWidth.js
+++ b/client/src/hooks/useElementWidth.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+const useElementWidth = (ref) => {
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const updateWidth = () => {
+      if (ref.current) {
+        setWidth(ref.current.offsetWidth);
+      }
+    };
+
+    updateWidth();
+
+    const resizeObserver = new ResizeObserver(updateWidth);
+    resizeObserver.observe(ref.current);
+    window.addEventListener('resize', updateWidth);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, [ref]);
+
+  return width;
+};
+
+export default useElementWidth;


### PR DESCRIPTION
## Summary
- measure element width with a new `useElementWidth` hook
- base `Event` time boxes and action button layout on the measured width
- use the same calculations in the `DayColumn` version of events

## Testing
- `npm test --prefix client -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_685425be1fd08325beead7ef9468581b