### PR TITLE
Fix mobile join button and time box width

### DIFF
--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -174,7 +174,9 @@ const ColumnEvent = ({
                     },
                     minWidth: isUserJoining(a) ? { xs: '80px', sm: '50px' } : { xs: '60px', sm: 'auto' },
                     height: { xs: '36px', sm: '24px' },
-                    justifyContent: 'flex-start',
+                    justifyContent: isUserJoining(a)
+                      ? 'flex-start'
+                      : { xs: 'center', sm: 'flex-start' },
                     gap: 0.5,
                     fontSize: { xs: '0.875rem', sm: '0.75rem' },
                     fontFamily: 'Nunito, sans-serif',
@@ -296,9 +298,11 @@ const DayColumn = ({
 }) => {
   const containerRef = useRef(null);
   const width = useElementWidth(containerRef);
-  const half = width / 2;
-  const timeBoxWidth = half - 16;
-  const actionsMaxWidth = half - 8;
+  const timeRatio = isMobile ? 0.25 : 0.5;
+  const timeBoxWidth = width * timeRatio - 16;
+  const actionsMaxWidth = isMobile
+    ? width - timeBoxWidth - 8
+    : width * 0.5 - 8;
   const handleSectionClick = (section, e) => {
     if (!isMobile) {
       handleDayClick(date, section, e);

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -1,10 +1,11 @@
 import React, { memo, useRef } from 'react';
-import { 
-  Paper, 
-  Typography, 
-  Box, 
-  IconButton, 
-  Tooltip 
+import {
+  Paper,
+  Typography,
+  Box,
+  IconButton,
+  Tooltip,
+  useMediaQuery
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import * as Icons from '@mui/icons-material';
@@ -23,9 +24,12 @@ const Event = memo(({
   const actionsRef = useRef(null);
   const width = useElementWidth(paperRef);
   const actionsWidth = useChildrenWidth(actionsRef);
-  const half = width / 2;
-  const timeBoxWidth = half - 16;
-  const actionsMaxWidth = half - 8;
+  const isMobile = useMediaQuery('(max-width:599px)');
+  const timeRatio = isMobile ? 0.25 : 0.5;
+  const timeBoxWidth = width * timeRatio - 16;
+  const actionsMaxWidth = isMobile
+    ? width - timeBoxWidth - 8
+    : width * 0.5 - 8;
   const shouldWrapActions = actionsWidth > actionsMaxWidth;
 
   return (
@@ -179,7 +183,9 @@ const Event = memo(({
               backgroundColor: 'rgba(255,255,255,0.3)'
             },
             minWidth: isUserJoining(event) ? '50px' : 'auto',
-            justifyContent: 'flex-start',
+            justifyContent: isUserJoining(event)
+              ? 'flex-start'
+              : { xs: 'center', sm: 'flex-start' },
             gap: 0.5,
             fontSize: '0.75rem',
             fontFamily: 'Nunito, sans-serif',


### PR DESCRIPTION
## Summary
- adjust mobile layout of DayColumn to cap time display at quarter of width
- center Join button text on mobile when not joined
- sync Event component logic with DayColumn for completeness
- prevent action buttons from wrapping on mobile

## Testing
- `npm install` in `client`
- `CI=true npm test --silent -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68545eeba0488325902398a7b95b3300