### PR TITLE
Neaten event time boxes and widen responsive breakpoint

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -308,8 +308,8 @@ const Calendar = () => {
   return (
     <Box sx={{
       p: 4,
-      height: { xs: 'calc(100dvh - 64px)', sm: 'calc(100vh - 64px)' },
-      minHeight: { xs: 'calc(100dvh - 64px)', sm: 'calc(100vh - 64px)' },
+      height: { xs: 'calc(100dvh - 64px)', md: 'calc(100vh - 64px)' },
+      minHeight: { xs: 'calc(100dvh - 64px)', md: 'calc(100vh - 64px)' },
       '--calendar-bg': pastelColor,
       backgroundColor: 'var(--calendar-bg)',
       color: darkMode ? '#fff' : 'inherit',
@@ -319,7 +319,7 @@ const Calendar = () => {
       willChange: 'background-color',
       display: 'flex',
       flexDirection: 'column',
-      overflow: { xs: 'auto', sm: 'hidden' }
+      overflow: { xs: 'auto', md: 'hidden' }
     }}>
       <Box sx={{ 
         display: 'flex', 
@@ -366,26 +366,26 @@ const Calendar = () => {
         setDarkMode={setDarkMode}
       />
 
-      <Paper sx={{ 
-        borderRadius: 2, 
-        overflow: 'hidden', 
+      <Paper sx={{
+        borderRadius: 2,
+        overflow: 'hidden',
         fontFamily: 'Nunito, sans-serif',
-        flex: { xs: 'none', sm: 1 },
+        flex: { xs: 'none', md: 1 },
         display: 'flex',
         flexDirection: 'column',
         minHeight: 0,
-        height: { xs: 'auto', sm: 'auto' },
-        maxHeight: { xs: 'none', sm: 'none' }
+        height: { xs: 'auto', md: 'auto' },
+        maxHeight: { xs: 'none', md: 'none' }
       }}>
-        <Grid 
-          container 
-          sx={{ 
-            flex: { xs: 'none', sm: 1 },
-            flexDirection: { xs: 'column', sm: 'row' },
+        <Grid
+          container
+          sx={{
+            flex: { xs: 'none', md: 1 },
+            flexDirection: { xs: 'column', md: 'row' },
             width: '100%',
-            minHeight: { sm: 0 },
-            overflow: { xs: 'visible', sm: 'hidden' },
-            height: { xs: 'auto', sm: 'auto' }
+            minHeight: { md: 0 },
+            overflow: { xs: 'visible', md: 'hidden' },
+            height: { xs: 'auto', md: 'auto' }
           }}
         >
           {getNextSevenDays().map((date, index) => {

--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -34,6 +34,9 @@ const ColumnEvent = ({
   const actionsRef = useRef(null);
   const actionsWidth = useChildrenWidth(actionsRef);
   const shouldWrapActions = actionsWidth > actionsMaxWidth;
+  const effectiveTimeBoxWidth = actionsWidth > 0
+    ? Math.min(timeBoxWidth, actionsWidth)
+    : timeBoxWidth;
 
   const a = availability;
 
@@ -52,8 +55,7 @@ const ColumnEvent = ({
         transition: 'all 0.2s ease',
         boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
         willChange: 'transform, box-shadow',
-        '&.event-paper:hover .time-box': {
-          top: { xs: 0, sm: '-36px' },
+        '&:hover .time-box': {
           backgroundColor: a.color,
           '&::before': {
             opacity: 0
@@ -109,8 +111,9 @@ const ColumnEvent = ({
               <Box
                 sx={{
                   position: 'absolute',
-                  top: { xs: 0, sm: activeEventId === a._id ? '-36px' : 0 },
-                  width: `${timeBoxWidth}px`,
+                  top: '50%',
+                  transform: 'translateY(-50%)',
+                  width: `${effectiveTimeBoxWidth}px`,
                   height: { xs: '36px', sm: '28px' },
                   borderRadius: '8px',
                   backgroundColor: 'rgba(255,255,255,0.235)',
@@ -127,7 +130,6 @@ const ColumnEvent = ({
                   whiteSpace: 'nowrap',
                   overflow: 'hidden',
                   maxWidth: `${actionsMaxWidth}px`,
-                  transition: { xs: 'none', sm: 'top 0.3s cubic-bezier(0.4,0,0.2,1)' },
                   zIndex: 2,
                   pointerEvents: 'none',
                   right: isMobile ? (isUserJoining(a) ? '180px' : '142px') : 0,
@@ -313,11 +315,11 @@ const DayColumn = ({
     <Grid
       item
       xs={12}
-      sm
+      md
       key={index}
       sx={{
-        borderRight: { sm: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none' },
-        borderBottom: { xs: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none', sm: 'none' },
+        borderRight: { md: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none' },
+        borderBottom: { xs: index < 6 ? `1px solid ${darkMode ? '#555' : '#e0e0e0'}` : 'none', md: 'none' },
         '&:last-child': {
           borderRight: 'none',
           borderBottom: 'none'
@@ -326,9 +328,9 @@ const DayColumn = ({
         flexDirection: 'column',
         minHeight: 0,
         overflow: 'hidden',
-        width: { xs: '100%', sm: 'auto' },
-        flex: { xs: 'none', sm: 1 },
-        height: { xs: 'auto', sm: '100%' }
+        width: { xs: '100%', md: 'auto' },
+        flex: { xs: 'none', md: 1 },
+        height: { xs: 'auto', md: '100%' }
       }}
     >
       <Box
@@ -342,7 +344,7 @@ const DayColumn = ({
           flexDirection: 'column',
           overflow: 'visible',
           minHeight: 0,
-          height: { xs: 'auto', sm: '100%' }
+          height: { xs: 'auto', md: '100%' }
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>

--- a/client/src/components/calendar/Event.js
+++ b/client/src/components/calendar/Event.js
@@ -26,10 +26,13 @@ const Event = memo(({
   const actionsWidth = useChildrenWidth(actionsRef);
   const isMobile = useMediaQuery('(max-width:599px)');
   const timeRatio = isMobile ? 0.25 : 0.5;
-  const timeBoxWidth = width * timeRatio - 16;
+  const preferredTimeWidth = width * timeRatio - 16;
   const actionsMaxWidth = isMobile
-    ? width - timeBoxWidth - 8
+    ? width - preferredTimeWidth - 8
     : width * 0.5 - 8;
+  const timeBoxWidth = actionsWidth > 0
+    ? Math.min(preferredTimeWidth, actionsWidth)
+    : preferredTimeWidth;
   const shouldWrapActions = actionsWidth > actionsMaxWidth;
 
   return (
@@ -100,7 +103,7 @@ const Event = memo(({
             <Tooltip title={event.timeSlot} arrow placement="top">
               <Box sx={{
                 width: `${timeBoxWidth}px`,
-                height: '40px',
+                height: '28px',
                 borderRadius: '8px',
                 backgroundColor: 'rgba(255,255,255,0.235)',
                 display: 'flex',


### PR DESCRIPTION
## Summary
- Align event time box with action buttons and limit its width
- Raise calendar breakpoint so day columns stack vertically on narrower screens

## Testing
- `CI=true npm test --prefix client` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3bfa40cc83259485128dda4b2e09