### PR TITLE
feat: persist and edit user name

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -47,8 +47,9 @@ const Calendar = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [userPreferences, setUserPreferences] = useState(() => {
     const storedColor = localStorage.getItem('preferredColor');
+    const storedName = localStorage.getItem('userName');
     return {
-      name: '',
+      name: storedName || '',
       color: storedColor || '#66BB6A'
     };
   });
@@ -86,6 +87,10 @@ const Calendar = () => {
   useEffect(() => {
     localStorage.setItem('preferredColor', userPreferences.color);
   }, [userPreferences.color]);
+
+  useEffect(() => {
+    localStorage.setItem('userName', userPreferences.name);
+  }, [userPreferences.name]);
 
   useEffect(() => {
     localStorage.setItem('darkMode', darkMode);

--- a/client/src/components/calendar/UserPreferences.js
+++ b/client/src/components/calendar/UserPreferences.js
@@ -1,10 +1,19 @@
-import React from 'react';
-import { Paper, Grid, TextField, Box, Switch, FormControlLabel } from '@mui/material';
+import React, { useState } from 'react';
+import { Paper, Grid, TextField, Box, Switch, FormControlLabel, IconButton, Typography } from '@mui/material';
 import ColorLensIcon from '@mui/icons-material/ColorLens';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
+import EditIcon from '@mui/icons-material/Edit';
 import { COLORS, getTextColor } from './colorUtils';
 
 const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, setSelectedColor, darkMode, setDarkMode }) => {
+  const [isEditingName, setIsEditingName] = useState(!userPreferences.name);
+
+  const handleNameBlur = () => {
+    if (userPreferences.name.trim()) {
+      setIsEditingName(false);
+    }
+  };
+
   return (
     <Paper sx={{
       p: 2,
@@ -17,29 +26,55 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
     }}>
       <Grid container spacing={2} alignItems="center">
         <Grid item xs={12} sm={4}>
-          <TextField
-            label="Your Name"
-            fullWidth
-            value={userPreferences.name}
-            onChange={(e) => setUserPreferences({ ...userPreferences, name: e.target.value })}
-            required
-            InputProps={{
-              sx: {
-                fontFamily: 'Nunito, sans-serif',
-                backgroundColor: darkMode ? '#616161' : 'white',
-                color: darkMode ? '#fff' : 'inherit',
-                '& fieldset': {
-                  borderColor: darkMode ? '#bbb' : 'inherit'
+          {isEditingName ? (
+            <TextField
+              label="Your Name"
+              fullWidth
+              value={userPreferences.name}
+              onChange={(e) => setUserPreferences({ ...userPreferences, name: e.target.value })}
+              onBlur={handleNameBlur}
+              autoFocus
+              required
+              InputProps={{
+                sx: {
+                  fontFamily: 'Nunito, sans-serif',
+                  backgroundColor: darkMode ? '#616161' : 'white',
+                  color: darkMode ? '#fff' : 'inherit',
+                  '& fieldset': {
+                    borderColor: darkMode ? '#bbb' : 'inherit'
+                  }
                 }
-              }
-            }}
-            InputLabelProps={{
-              sx: {
+              }}
+              InputLabelProps={{
+                sx: {
+                  fontFamily: 'Nunito, sans-serif',
+                  color: darkMode ? '#fff' : 'inherit'
+                }
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
                 fontFamily: 'Nunito, sans-serif',
-                color: darkMode ? '#fff' : 'inherit'
-              }
-            }}
-          />
+                color: darkMode ? '#fff' : 'inherit',
+                width: '100%'
+              }}
+            >
+              <Typography sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}>
+                {userPreferences.name}
+              </Typography>
+              <IconButton
+                aria-label="edit name"
+                onClick={() => setIsEditingName(true)}
+                size="small"
+                sx={{ ml: 1, color: darkMode ? '#fff' : 'inherit' }}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          )}
         </Grid>
         <Grid item xs={12} sm={8}>
           <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: { xs: 'wrap', sm: 'nowrap' } }}>
@@ -53,6 +88,9 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
                 sx={{
                   width: 32,
                   height: 32,
+                  minWidth: 32,
+                  minHeight: 32,
+                  flexShrink: 0,
                   backgroundColor: color.value,
                   borderRadius: '50%',
                   cursor: 'pointer',
@@ -73,6 +111,9 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
               sx={{
                 width: 32,
                 height: 32,
+                minWidth: 32,
+                minHeight: 32,
+                flexShrink: 0,
                 backgroundColor: selectedColor,
                 borderRadius: '50%',
                 cursor: 'pointer',
@@ -138,4 +179,4 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
   );
 };
 
-export default UserPreferences; 
+export default UserPreferences;


### PR DESCRIPTION
## Summary
- toggle between name input and display with edit icon
- persist user name using localStorage for reuse across sessions
- hide outline around saved name and keep color presets perfectly circular

## Testing
- `npm test` (fails: Missing script "test")
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689dfe011dc083259802800a5d48a58a