### PR TITLE
feat: persist and edit user name

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -47,8 +47,9 @@ const Calendar = () => {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [userPreferences, setUserPreferences] = useState(() => {
     const storedColor = localStorage.getItem('preferredColor');
+    const storedName = localStorage.getItem('userName');
     return {
-      name: '',
+      name: storedName || '',
       color: storedColor || '#66BB6A'
     };
   });
@@ -86,6 +87,10 @@ const Calendar = () => {
   useEffect(() => {
     localStorage.setItem('preferredColor', userPreferences.color);
   }, [userPreferences.color]);
+
+  useEffect(() => {
+    localStorage.setItem('userName', userPreferences.name);
+  }, [userPreferences.name]);
 
   useEffect(() => {
     localStorage.setItem('darkMode', darkMode);

--- a/client/src/components/calendar/CalendarDay.js
+++ b/client/src/components/calendar/CalendarDay.js
@@ -76,6 +76,11 @@ const CalendarDay = memo(({
           size="small"
           color="primary"
           sx={{
+            width: 40,
+            height: 40,
+            minWidth: 40,
+            minHeight: 40,
+            flexShrink: 0,
             backgroundColor: userPreferences.color,
             color: getTextColor(userPreferences.color),
             transition: 'all 0.5s ease',

--- a/client/src/components/calendar/DayColumn.js
+++ b/client/src/components/calendar/DayColumn.js
@@ -384,6 +384,11 @@ const DayColumn = ({
             size="small"
             color="primary"
             sx={{
+              width: 40,
+              height: 40,
+              minWidth: 40,
+              minHeight: 40,
+              flexShrink: 0,
               backgroundColor: userPreferences.color,
               color: getTextColor(userPreferences.color),
               transition: 'all 0.5s ease',

--- a/client/src/components/calendar/UserPreferences.js
+++ b/client/src/components/calendar/UserPreferences.js
@@ -1,48 +1,87 @@
-import React from 'react';
-import { Paper, Grid, TextField, Box, Switch, FormControlLabel } from '@mui/material';
+import React, { useState } from 'react';
+import { Paper, Grid, TextField, Box, Switch, FormControlLabel, IconButton, Typography } from '@mui/material';
 import ColorLensIcon from '@mui/icons-material/ColorLens';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
+import EditIcon from '@mui/icons-material/Edit';
 import { COLORS, getTextColor } from './colorUtils';
 
 const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, setSelectedColor, darkMode, setDarkMode }) => {
+  const [isEditingName, setIsEditingName] = useState(!userPreferences.name);
+
+  const handleNameBlur = () => {
+    if (userPreferences.name.trim()) {
+      setIsEditingName(false);
+    }
+  };
+
   return (
     <Paper sx={{
       p: 2,
       mb: 3,
       borderRadius: 2,
       fontFamily: 'Nunito, sans-serif',
-      width: 'fit-content',
+      width: '100%',
+      maxWidth: 600,
       backgroundColor: darkMode ? '#424242' : 'white',
       color: darkMode ? '#fff' : 'inherit'
     }}>
       <Grid container spacing={2} alignItems="center">
         <Grid item xs={12} sm={4}>
-          <TextField
-            label="Your Name"
-            fullWidth
-            value={userPreferences.name}
-            onChange={(e) => setUserPreferences({ ...userPreferences, name: e.target.value })}
-            required
-            InputProps={{
-              sx: {
-                fontFamily: 'Nunito, sans-serif',
-                backgroundColor: darkMode ? '#616161' : 'white',
-                color: darkMode ? '#fff' : 'inherit',
-                '& fieldset': {
-                  borderColor: darkMode ? '#bbb' : 'inherit'
+          {isEditingName ? (
+            <TextField
+              label="Your Name"
+              fullWidth
+              value={userPreferences.name}
+              onChange={(e) => setUserPreferences({ ...userPreferences, name: e.target.value })}
+              onBlur={handleNameBlur}
+              autoFocus
+              required
+              InputProps={{
+                sx: {
+                  fontFamily: 'Nunito, sans-serif',
+                  backgroundColor: darkMode ? '#616161' : 'white',
+                  color: darkMode ? '#fff' : 'inherit',
+                  '& fieldset': {
+                    borderColor: darkMode ? '#bbb' : 'inherit'
+                  }
                 }
-              }
-            }}
-            InputLabelProps={{
-              sx: {
+              }}
+              InputLabelProps={{
+                sx: {
+                  fontFamily: 'Nunito, sans-serif',
+                  color: darkMode ? '#fff' : 'inherit'
+                }
+              }}
+            />
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
                 fontFamily: 'Nunito, sans-serif',
-                color: darkMode ? '#fff' : 'inherit'
-              }
-            }}
-          />
+                color: darkMode ? '#fff' : 'inherit',
+                width: '100%'
+              }}
+            >
+              <Typography
+                variant="h6"
+                sx={{ fontFamily: 'Nunito, sans-serif', color: darkMode ? '#fff' : 'inherit' }}
+              >
+                {userPreferences.name}
+              </Typography>
+              <IconButton
+                aria-label="edit name"
+                onClick={() => setIsEditingName(true)}
+                size="small"
+                sx={{ ml: 1, color: darkMode ? '#fff' : 'inherit' }}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          )}
         </Grid>
         <Grid item xs={12} sm={8}>
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: { xs: 'wrap', sm: 'nowrap' } }}>
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap' }}>
             {COLORS.map((color) => (
               <Box
                 key={color.value}
@@ -53,6 +92,9 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
                 sx={{
                   width: 32,
                   height: 32,
+                  minWidth: 32,
+                  minHeight: 32,
+                  flexShrink: 0,
                   backgroundColor: color.value,
                   borderRadius: '50%',
                   cursor: 'pointer',
@@ -73,6 +115,9 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
               sx={{
                 width: 32,
                 height: 32,
+                minWidth: 32,
+                minHeight: 32,
+                flexShrink: 0,
                 backgroundColor: selectedColor,
                 borderRadius: '50%',
                 cursor: 'pointer',
@@ -125,6 +170,7 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
               ml: { xs: 0, sm: 2 },
               mt: { xs: 1, sm: 0 },
               flexBasis: { xs: '100%', sm: 'auto' },
+              flexShrink: 0,
               alignItems: 'center',
               '& .MuiFormControlLabel-label': {
                 fontSize: 28
@@ -138,4 +184,4 @@ const UserPreferences = ({ userPreferences, setUserPreferences, selectedColor, s
   );
 };
 
-export default UserPreferences; 
+export default UserPreferences;


### PR DESCRIPTION
## Summary
- toggle between name input and display with edit icon
- persist user name using localStorage for reuse across sessions
- ensure color presets and day FAB buttons stay perfectly circular
- wrap preferences panel and cap width so dark mode toggle stays inside

## Testing
- `npm test` (fails: Missing script "test")
- `cd client && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689dfe011dc083259802800a5d48a58a