### PR TITLE
Add recurring events option

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -67,7 +67,8 @@ const Calendar = () => {
     timeSlot: '',
     location: '',
     section: 'day',
-    icon: ''
+    icon: '',
+    recurring: false
   });
   const [selectedColor, setSelectedColor] = useState(() => {
     const storedColor = localStorage.getItem('preferredColor');
@@ -129,7 +130,8 @@ const Calendar = () => {
       timeSlot: '',
       location: '',
       section: section,
-      icon: ''
+      icon: '',
+      recurring: false
     });
     setOpenDialog(true);
   }, [userPreferences.name, setError]);
@@ -203,7 +205,8 @@ const Calendar = () => {
       timeSlot: event.timeSlot,
       location: event.location,
       section: event.section,
-      icon: event.icon || ''
+      icon: event.icon || '',
+      recurring: event.recurring || false
     });
     setOpenEditDialog(true);
   }, [userPreferences.name, setError]);
@@ -234,6 +237,31 @@ const Calendar = () => {
       handleEditSubmit();
     }
   }, [newEvent, handleEditSubmit]);
+
+  const expandedAvailabilities = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const rangeEnd = new Date(today);
+    rangeEnd.setDate(rangeEnd.getDate() + 6);
+    const expanded = [];
+
+    availabilities.forEach(event => {
+      if (event.recurring) {
+        let occurrence = new Date(event.date);
+        occurrence.setHours(0, 0, 0, 0);
+        while (occurrence < today) {
+          occurrence.setDate(occurrence.getDate() + 7);
+        }
+        while (occurrence <= rangeEnd) {
+          expanded.push({ ...event, date: occurrence.toISOString() });
+          occurrence.setDate(occurrence.getDate() + 7);
+        }
+      } else {
+        expanded.push(event);
+      }
+    });
+    return expanded;
+  }, [availabilities]);
 
   const getNextSevenDays = () => {
     const days = [];
@@ -475,7 +503,7 @@ const Calendar = () => {
           }}
         >
           {getNextSevenDays().map((date, index) => {
-            const dayAvailabilities = availabilities.filter(a =>
+            const dayAvailabilities = expandedAvailabilities.filter(a =>
               new Date(a.date).toDateString() === date.toDateString()
             );
 

--- a/client/src/components/calendar/AddEventDialog.js
+++ b/client/src/components/calendar/AddEventDialog.js
@@ -10,7 +10,9 @@ import {
   TextField,
   Box,
   Alert,
-  Typography
+  Typography,
+  FormControlLabel,
+  Checkbox
 } from '@mui/material';
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
@@ -389,11 +391,33 @@ const AddEventDialog = ({
               }
             }}
             InputLabelProps={{
-              sx: { 
-                fontFamily: 'Nunito, sans-serif', 
+              sx: {
+                fontFamily: 'Nunito, sans-serif',
                 color: darkMode ? '#ccc' : '#666',
                 fontWeight: 600
               }
+            }}
+          />
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={newEvent.recurring || false}
+                onChange={(e) => setNewEvent({ ...newEvent, recurring: e.target.checked })}
+                sx={{
+                  color: darkMode ? '#ccc' : '#666',
+                  '&.Mui-checked': {
+                    color: userPreferences.color
+                  }
+                }}
+              />
+            }
+            label="Repeat weekly"
+            sx={{
+              mt: 1,
+              fontFamily: 'Nunito, sans-serif',
+              color: darkMode ? '#ccc' : '#666',
+              fontWeight: 600
             }}
           />
         </Box>
@@ -476,6 +500,7 @@ AddEventDialog.propTypes = {
     location: PropTypes.string,
     section: PropTypes.string,
     icon: PropTypes.string,
+    recurring: PropTypes.bool,
   }).isRequired,
   setNewEvent: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/client/src/components/calendar/EditEventDialog.js
+++ b/client/src/components/calendar/EditEventDialog.js
@@ -10,7 +10,9 @@ import {
   TextField,
   Box,
   Alert,
-  Typography
+  Typography,
+  FormControlLabel,
+  Checkbox
 } from '@mui/material';
 import { getTextColor } from './colorUtils';
 import IconPickerDialog from './IconPickerDialog';
@@ -374,11 +376,33 @@ const EditEventDialog = ({
               }
             }}
             InputLabelProps={{
-              sx: { 
-                fontFamily: 'Nunito, sans-serif', 
+              sx: {
+                fontFamily: 'Nunito, sans-serif',
                 color: darkMode ? '#ccc' : '#666',
                 fontWeight: 600
               }
+            }}
+          />
+
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={newEvent.recurring || false}
+                onChange={(e) => setNewEvent({ ...newEvent, recurring: e.target.checked })}
+                sx={{
+                  color: darkMode ? '#ccc' : '#666',
+                  '&.Mui-checked': {
+                    color: userPreferences.color
+                  }
+                }}
+              />
+            }
+            label="Repeat weekly"
+            sx={{
+              mt: 1,
+              fontFamily: 'Nunito, sans-serif',
+              color: darkMode ? '#ccc' : '#666',
+              fontWeight: 600
             }}
           />
         </Box>
@@ -461,6 +485,7 @@ EditEventDialog.propTypes = {
     location: PropTypes.string,
     section: PropTypes.string,
     icon: PropTypes.string,
+    recurring: PropTypes.bool,
   }).isRequired,
   setNewEvent: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/server.js
+++ b/server.js
@@ -58,6 +58,10 @@ const availabilitySchema = new mongoose.Schema({
   name: String,
   color: String,
   icon: String,
+  recurring: {
+    type: Boolean,
+    default: false
+  },
   section: {
     type: String,
     enum: ['day', 'evening'],


### PR DESCRIPTION
## Summary
- allow events to repeat weekly via new checkbox in add/edit dialogs
- support recurring events in calendar logic and backend schema

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68adb6f0d4a08325b6c476e4e96255ae